### PR TITLE
Feat: migrate back-end from old app #78

### DIFF
--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -26,7 +26,8 @@ const apiResources: ResourceController[] = [
   { name: 'eventSpots', paths: ['/event-spots', '/event-spots/{spotId}'] },
   { name: 'usefulLinks', paths: ['/useful-links', '/useful-links/{linkId}'] },
   { name: 'venues', paths: ['/venues', '/venues/{venueId}'] },
-  { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] }
+  { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] },
+  { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -50,6 +51,13 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   communications: {
     PK: { name: 'communicationId', type: DDB.AttributeType.STRING }
+  },
+  usersReadCommunications: {
+    PK: { name: 'userId', type: DDB.AttributeType.STRING },
+    SK: { name: 'communicationId', type: DDB.AttributeType.STRING }
+  },
+  organizations: {
+    PK: { name: 'organizationId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -24,7 +24,8 @@ const apiResources: ResourceController[] = [
   { name: 'configurations', paths: ['/configurations'] },
   { name: 'users', paths: ['/users', '/users/{userId}'] },
   { name: 'eventSpots', paths: ['/event-spots', '/event-spots/{spotId}'] },
-  { name: 'usefulLinks', paths: ['/useful-links', '/useful-links/{linkId}'] }
+  { name: 'usefulLinks', paths: ['/useful-links', '/useful-links/{linkId}'] },
+  { name: 'venues', paths: ['/venues', '/venues/{venueId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -42,6 +43,9 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   usefulLinks: {
     PK: { name: 'linkId', type: DDB.AttributeType.STRING }
+  },
+  venues: {
+    PK: { name: 'venueId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -27,7 +27,8 @@ const apiResources: ResourceController[] = [
   { name: 'usefulLinks', paths: ['/useful-links', '/useful-links/{linkId}'] },
   { name: 'venues', paths: ['/venues', '/venues/{venueId}'] },
   { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] },
-  { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] }
+  { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] },
+  { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -58,6 +59,9 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   organizations: {
     PK: { name: 'organizationId', type: DDB.AttributeType.STRING }
+  },
+  rooms: {
+    PK: { name: 'roomId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -29,7 +29,8 @@ const apiResources: ResourceController[] = [
   { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] },
   { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] },
   { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] },
-  { name: 'speakers', paths: ['/speakers', '/speakers/{speakerId}'] }
+  { name: 'speakers', paths: ['/speakers', '/speakers/{speakerId}'] },
+  { name: 'sessions', paths: ['/sessions', '/sessions/{sessionId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -66,6 +67,9 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   speakers: {
     PK: { name: 'speakerId', type: DDB.AttributeType.STRING }
+  },
+  sessions: {
+    PK: { name: 'sessionId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -28,7 +28,8 @@ const apiResources: ResourceController[] = [
   { name: 'venues', paths: ['/venues', '/venues/{venueId}'] },
   { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] },
   { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] },
-  { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] }
+  { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] },
+  { name: 'speakers', paths: ['/speakers', '/speakers/{speakerId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -62,6 +63,9 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   rooms: {
     PK: { name: 'roomId', type: DDB.AttributeType.STRING }
+  },
+  speakers: {
+    PK: { name: 'speakerId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -25,7 +25,8 @@ const apiResources: ResourceController[] = [
   { name: 'users', paths: ['/users', '/users/{userId}'] },
   { name: 'eventSpots', paths: ['/event-spots', '/event-spots/{spotId}'] },
   { name: 'usefulLinks', paths: ['/useful-links', '/useful-links/{linkId}'] },
-  { name: 'venues', paths: ['/venues', '/venues/{venueId}'] }
+  { name: 'venues', paths: ['/venues', '/venues/{venueId}'] },
+  { name: 'communications', paths: ['/communications', '/communications/{communicationId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -46,6 +47,9 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   venues: {
     PK: { name: 'venueId', type: DDB.AttributeType.STRING }
+  },
+  communications: {
+    PK: { name: 'communicationId', type: DDB.AttributeType.STRING }
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -83,6 +83,18 @@ const tables: { [tableName: string]: DDBTable } = {
         projectionType: DDB.ProjectionType.ALL
       }
     ]
+  },
+  usersFavoriteSessions: {
+    PK: { name: 'userId', type: DDB.AttributeType.STRING },
+    SK: { name: 'sessionId', type: DDB.AttributeType.STRING },
+    indexes: [
+      {
+        indexName: 'inverted-index',
+        partitionKey: { name: 'sessionId', type: DDB.AttributeType.STRING },
+        sortKey: { name: 'userId', type: DDB.AttributeType.STRING },
+        projectionType: DDB.ProjectionType.ALL
+      }
+    ]
   }
 };
 

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -31,7 +31,8 @@ const apiResources: ResourceController[] = [
   { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] },
   { name: 'speakers', paths: ['/speakers', '/speakers/{speakerId}'] },
   { name: 'sessions', paths: ['/sessions', '/sessions/{sessionId}'] },
-  { name: 'registrations', paths: ['/registrations', '/registrations/{sessionId}'] }
+  { name: 'registrations', paths: ['/registrations', '/registrations/{sessionId}'] },
+  { name: 'connections', paths: ['/connections', '/connections/{connectionId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -92,6 +93,23 @@ const tables: { [tableName: string]: DDBTable } = {
         indexName: 'inverted-index',
         partitionKey: { name: 'sessionId', type: DDB.AttributeType.STRING },
         sortKey: { name: 'userId', type: DDB.AttributeType.STRING },
+        projectionType: DDB.ProjectionType.ALL
+      }
+    ]
+  },
+  connections: {
+    PK: { name: 'connectionId', type: DDB.AttributeType.STRING },
+    indexes: [
+      {
+        indexName: 'requesterId-targetId-index',
+        partitionKey: { name: 'requesterId', type: DDB.AttributeType.STRING },
+        sortKey: { name: 'targetId', type: DDB.AttributeType.STRING },
+        projectionType: DDB.ProjectionType.ALL
+      },
+      {
+        indexName: 'targetId-requesterId-index',
+        partitionKey: { name: 'targetId', type: DDB.AttributeType.STRING },
+        sortKey: { name: 'requesterId', type: DDB.AttributeType.STRING },
         projectionType: DDB.ProjectionType.ALL
       }
     ]

--- a/back-end/deploy/main.ts
+++ b/back-end/deploy/main.ts
@@ -30,7 +30,8 @@ const apiResources: ResourceController[] = [
   { name: 'organizations', paths: ['/organizations', '/organizations/{organizationId}'] },
   { name: 'rooms', paths: ['/rooms', '/rooms/{roomId}'] },
   { name: 'speakers', paths: ['/speakers', '/speakers/{speakerId}'] },
-  { name: 'sessions', paths: ['/sessions', '/sessions/{sessionId}'] }
+  { name: 'sessions', paths: ['/sessions', '/sessions/{sessionId}'] },
+  { name: 'registrations', paths: ['/registrations', '/registrations/{sessionId}'] }
 ];
 
 const tables: { [tableName: string]: DDBTable } = {
@@ -70,6 +71,18 @@ const tables: { [tableName: string]: DDBTable } = {
   },
   sessions: {
     PK: { name: 'sessionId', type: DDB.AttributeType.STRING }
+  },
+  registrations: {
+    PK: { name: 'sessionId', type: DDB.AttributeType.STRING },
+    SK: { name: 'userId', type: DDB.AttributeType.STRING },
+    indexes: [
+      {
+        indexName: 'userId-sessionId-index',
+        partitionKey: { name: 'userId', type: DDB.AttributeType.STRING },
+        sortKey: { name: 'sessionId', type: DDB.AttributeType.STRING },
+        projectionType: DDB.ProjectionType.ALL
+      }
+    ]
   }
 };
 

--- a/back-end/src/handlers/communications.ts
+++ b/back-end/src/handlers/communications.ts
@@ -27,8 +27,6 @@ export const handler = (ev: any, _: any, cb: any) => new Communications(ev, cb).
 /// RESOURCE CONTROLLER
 ///
 
-// @todo check permissions here
-
 class Communications extends ResourceController {
   user: User;
   communication: Communication;

--- a/back-end/src/handlers/communications.ts
+++ b/back-end/src/handlers/communications.ts
@@ -1,0 +1,159 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Communication, CommunicationWithMarker } from '../models/communication.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  communications: process.env.DDB_TABLE_communications,
+  usersReadCommunications: process.env.DDB_TABLE_usersReadCommunications
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Communications(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+// @todo check permissions here
+
+class Communications extends ResourceController {
+  user: User;
+  communication: Communication;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'communicationId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.communication = new Communication(
+        await ddb.get({ TableName: DDB_TABLES.communications, Key: { communicationId: this.resourceId } })
+      );
+    } catch (err) {
+      throw new RCError('Communication not found');
+    }
+  }
+
+  protected async getResource(): Promise<CommunicationWithMarker> {
+    const communication = this.communication as CommunicationWithMarker;
+
+    try {
+      await ddb.get({
+        TableName: DDB_TABLES.usersReadCommunications,
+        Key: { userId: this.principalId, communicationId: this.resourceId }
+      });
+      communication.hasBeenReadByUser = true;
+      return communication;
+    } catch (unread) {
+      return communication;
+    }
+  }
+
+  protected async putResource(): Promise<Communication> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Communication(this.communication);
+    this.communication.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Communication> {
+    const errors = this.communication.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.communications, Item: this.communication };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(communicationId)';
+      await ddb.put(putParams);
+
+      return this.communication;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async patchResource(): Promise<void> {
+    switch (this.body.action) {
+      case 'MARK_AS_READ':
+        return await this.markAsReadForUser(true);
+      case 'MARK_AS_UNREAD':
+        return await this.markAsReadForUser(false);
+      default:
+        throw new RCError('Unsupported action');
+    }
+  }
+  private async markAsReadForUser(markRead: boolean): Promise<void> {
+    const marker = { userId: this.principalId, communicationId: this.resourceId };
+
+    if (markRead) await ddb.put({ TableName: DDB_TABLES.usersReadCommunications, Item: marker });
+    else await ddb.delete({ TableName: DDB_TABLES.usersReadCommunications, Key: marker });
+  }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.communications, Key: { communicationId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Communication> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.communication = new Communication(this.body);
+    this.communication.communicationId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<CommunicationWithMarker[]> {
+    try {
+      const communications = (await ddb.scan({ TableName: DDB_TABLES.communications })).map(
+        x => new CommunicationWithMarker(x)
+      );
+
+      const usersReadCommunications = new Set(
+        (
+          await ddb.query({
+            TableName: DDB_TABLES.usersReadCommunications,
+            KeyConditionExpression: 'userId = :userId',
+            ExpressionAttributeValues: { ':userId': this.principalId }
+          })
+        ).map(x => x.communicationId)
+      );
+
+      communications.forEach(c => {
+        if (usersReadCommunications.has(c.communicationId)) c.hasBeenReadByUser = true;
+      });
+
+      const sortedCommunications = communications.sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
+
+      return sortedCommunications;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/handlers/connections.ts
+++ b/back-end/src/handlers/connections.ts
@@ -1,0 +1,151 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Connection, ConnectionWithUserData } from '../models/connection.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  connections: process.env.DDB_TABLE_connections
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Connections(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Connections extends ResourceController {
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'connectionId' });
+  }
+
+  protected async getResources(): Promise<ConnectionWithUserData[]> {
+    try {
+      const connectionsFromBothSides = await Promise.all([
+        ddb.query({
+          TableName: DDB_TABLES.connections,
+          IndexName: 'requesterId-targetId-index',
+          KeyConditionExpression: 'requesterId = :userId',
+          ExpressionAttributeValues: { ':userId': this.principalId }
+        }),
+        ddb.query({
+          TableName: DDB_TABLES.connections,
+          IndexName: 'targetId-requesterId-index',
+          KeyConditionExpression: 'targetId = :userId',
+          ExpressionAttributeValues: { ':userId': this.principalId }
+        })
+      ]);
+
+      const connections: Connection[] = [...connectionsFromBothSides[0], ...connectionsFromBothSides[1]];
+      if (!connections.length) return [];
+
+      const usersProfileToGather = [
+        ...connectionsFromBothSides[0].map(x => ({ userId: x.targetId })),
+        ...connectionsFromBothSides[1].map(x => ({ userId: x.requesterId }))
+      ];
+      const connectionsProfiles = await ddb.batchGet(DDB_TABLES.users, usersProfileToGather, true);
+      const userConnections = connections
+        .map(x => {
+          const otherUserId = x.requesterId === this.principalId ? x.targetId : x.requesterId;
+          const userProfile = connectionsProfiles.find(u => u.userId === otherUserId);
+          return userProfile ? new ConnectionWithUserData({ ...x, userProfile }) : null;
+        })
+        .filter(x => x?.userProfile.getName());
+
+      const sortedUserConnections = userConnections.sort((a, b) =>
+        a.userProfile.getName().localeCompare(b.userProfile.getName())
+      );
+
+      return sortedUserConnections;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async postResources(): Promise<ConnectionWithUserData> {
+    if (!this.body.userId) throw new RCError('Missing target user');
+    if (this.principalId === this.body.userId) throw new RCError('Same user');
+
+    let target: User;
+    try {
+      target = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.body.userId } }));
+    } catch (error) {
+      throw new RCError('Target profile not found');
+    }
+    if (!target.getName()) throw new RCError('Target profile incomplete');
+
+    let connection = await this.getConnectionOfUserWithTarget(target.userId);
+    if (connection) {
+      if (connection.requesterId === this.principalId) {
+        if (connection.isPending) throw new RCError('Connection is pending');
+        else throw new RCError('Already connected');
+      } else {
+        if (connection.isPending) delete connection.isPending;
+        else throw new RCError('Already connected');
+      }
+    } else {
+      connection = new Connection({
+        connectionId: await ddb.IUNID(PROJECT),
+        requesterId: this.principalId,
+        targetId: target.userId,
+        isPending: true
+      });
+    }
+
+    try {
+      await ddb.put({ TableName: DDB_TABLES.connections, Item: connection });
+
+      return new ConnectionWithUserData({ ...connection, userProfile: target });
+    } catch (err) {
+      throw new RCError('Connection failed');
+    }
+  }
+
+  protected async deleteResource(): Promise<void> {
+    let connection: Connection;
+    try {
+      connection = await ddb.get({ TableName: DDB_TABLES.connections, Key: { connectionId: this.resourceId } });
+    } catch (error) {
+      throw new RCError('Not found');
+    }
+
+    if (connection.requesterId !== this.principalId && connection.targetId !== this.principalId)
+      throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.connections, Key: { connectionId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  private async getConnectionOfUserWithTarget(targetUserId: string): Promise<Connection> {
+    const connectionWithUserAsRequester = await ddb.query({
+      TableName: DDB_TABLES.connections,
+      IndexName: 'requesterId-targetId-index',
+      KeyConditionExpression: 'requesterId = :requesterId AND targetId = :targetId',
+      ExpressionAttributeValues: { ':requesterId': this.principalId, ':targetId': targetUserId }
+    });
+    const connectionWithUserAsTarget = await ddb.query({
+      TableName: DDB_TABLES.connections,
+      IndexName: 'targetId-requesterId-index',
+      KeyConditionExpression: 'requesterId = :requesterId AND targetId = :targetId',
+      ExpressionAttributeValues: { ':requesterId': targetUserId, ':targetId': this.principalId }
+    });
+    const connection = connectionWithUserAsRequester[0] || connectionWithUserAsTarget[0];
+
+    return connection ? new Connection(connection) : null;
+  }
+}

--- a/back-end/src/handlers/organizations.ts
+++ b/back-end/src/handlers/organizations.ts
@@ -1,0 +1,167 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Organization } from '../models/organization.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = { users: process.env.DDB_TABLE_users, organizations: process.env.DDB_TABLE_organizations };
+
+// @todo add CV stuff?
+// const SES_CONFIG = {
+//   sourceName: 'EGM',
+//   source: process.env.SES_SOURCE_ADDRESS,
+//   sourceArn: process.env.SES_IDENTITY_ARN,
+//   region: process.env.SES_REGION
+// };
+
+// const EMAIL_CONTENTS = {
+//   subject: '[EGM] Contact request',
+//   textHeader:
+//     "Hi,\nthis is an automatic email from the EGM app.\n\nI'd like to get in touch with your organization; therefore, here is my contact information:\n\n",
+//   textAttachment: '\n\nYou can find attached my CV.\n',
+//   textFooter: '\n\nBest regards,\n'
+// };
+
+// const S3_BUCKET_MEDIA = process.env.S3_BUCKET_MEDIA;
+// const S3_USERS_CV_FOLDER = process.env.S3_USERS_CV_FOLDER;
+
+const ddb = new DynamoDB();
+// const ses = new SES();
+// const s3 = new S3();
+
+export const handler = (ev: any, _: any, cb: any) => new Organizations(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Organizations extends ResourceController {
+  user: User;
+  organization: Organization;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'organizationId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.organization = new Organization(
+        await ddb.get({ TableName: DDB_TABLES.organizations, Key: { organizationId: this.resourceId } })
+      );
+    } catch (err) {
+      throw new RCError('Organization not found');
+    }
+  }
+
+  protected async getResource(): Promise<Organization> {
+    return this.organization;
+  }
+
+  protected async putResource(): Promise<Organization> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Organization(this.organization);
+    this.organization.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Organization> {
+    const errors = this.organization.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.organizations, Item: this.organization };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(organizationId)';
+      await ddb.put(putParams);
+
+      return this.organization;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  // protected async patchResource(): Promise<void> {
+  //   switch (this.body.action) {
+  //     case 'SEND_USER_CONTACTS':
+  //       return await this.sendUserContacts();
+  //     default:
+  //       throw new RCError('Unsupported action');
+  //   }
+  // }
+
+  // @todo?
+  // private async sendUserContacts(): Promise<void> {
+  // if (!this.organization.contactEmail) throw new Error('No target email address');
+  // const userProfile = new UserProfile(
+  //   await ddb.get({
+  //     TableName: DDB_TABLES.profiles,
+  //     Key: { userId: this.cognitoUser.userId }
+  //   })
+  // );
+  // if (!userProfile.contactEmail) throw new Error('No source email address');
+  // const emailData: EmailData = {
+  //   toAddresses: [this.organization.contactEmail],
+  //   replyToAddresses: [userProfile.contactEmail],
+  //   subject: EMAIL_CONTENTS.subject
+  // };
+  // let emailText = EMAIL_CONTENTS.textHeader;
+  // const contactInfo = [userProfile.getName(), userProfile.contactEmail];
+  // if (this.body.sendPhone) contactInfo.push(userProfile.contactPhone);
+  // emailText = emailText.concat(contactInfo.map(x => `- ${x}`).join('\n'));
+  // if (this.body.sendCV && userProfile.hasUploadedCV) {
+  //   const key = S3_USERS_CV_FOLDER.concat('/', this.cognitoUser.userId, '.pdf');
+  //   const { url } = s3.signedURLGet(S3_BUCKET_MEDIA, key);
+  //   emailData.attachments = [{ path: url, filename: 'CV.pdf', contentType: 'application/pdf' }];
+  //   emailText = emailText.concat(EMAIL_CONTENTS.textAttachment);
+  // }
+  // emailText = emailText.concat(EMAIL_CONTENTS.textFooter, userProfile.getName());
+  // emailData.text = emailText;
+  // await ses.sendEmail(emailData, SES_CONFIG);
+  // }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.organizations, Key: { organizationId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Organization> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.organization = new Organization(this.body);
+    this.organization.organizationId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<Organization[]> {
+    try {
+      return (await ddb.scan({ TableName: DDB_TABLES.organizations }))
+        .map((x: Organization) => new Organization(x))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/handlers/registrations.ts
+++ b/back-end/src/handlers/registrations.ts
@@ -1,0 +1,190 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Session } from '../models/session.model';
+import { SessionRegistration } from '../models/sessionRegistration.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  sessions: process.env.DDB_TABLE_sessions,
+  registrations: process.env.DDB_TABLE_registrations
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new SessionRegistrations(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class SessionRegistrations extends ResourceController {
+  user: User;
+  registration: SessionRegistration;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'sessionId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.registration = new SessionRegistration(
+        await ddb.get({
+          TableName: DDB_TABLES.registrations,
+          Key: { sessionId: this.resourceId, userId: this.principalId }
+        })
+      );
+    } catch (err) {
+      throw new RCError('Registration not found');
+    }
+  }
+
+  protected async getResources(): Promise<SessionRegistration[]> {
+    if (this.queryParams.sessionId) {
+      try {
+        const registrationsOfSession = await ddb.query({
+          TableName: DDB_TABLES.registrations,
+          KeyConditionExpression: 'sessionId = :sessionId',
+          ExpressionAttributeValues: { ':sessionId': this.queryParams.sessionId }
+        });
+        return registrationsOfSession.map(s => new SessionRegistration(s));
+      } catch (error) {
+        throw new RCError('Could not load registrations for this session');
+      }
+    } else {
+      return await this.getUsersRegistrations(this.principalId);
+    }
+  }
+
+  protected async postResources(): Promise<any> {
+    // @todo configurations.canSignUpForSessions()
+
+    if (!this.body.sessionId) throw new RCError('Missing session ID!');
+
+    this.registration = new SessionRegistration({
+      sessionId: this.body.sessionId,
+      userId: this.principalId,
+      registrationDateInMs: new Date().getTime()
+    });
+
+    return await this.putSafeResource();
+  }
+
+  protected async getResource(): Promise<SessionRegistration> {
+    return this.registration;
+  }
+
+  protected async deleteResource(): Promise<void> {
+    // @todo configurations.canSignUpForSessions()
+
+    try {
+      const { sessionId, userId } = this.registration;
+
+      const deleteSessionRegistration = { TableName: DDB_TABLES.registrations, Key: { sessionId, userId } };
+
+      const updateSessionCount = {
+        TableName: DDB_TABLES.sessions,
+        Key: { sessionId },
+        UpdateExpression: 'ADD numberOfParticipants :minusOne',
+        ExpressionAttributeValues: {
+          ':minusOne': -1
+        }
+      };
+
+      await ddb.transactWrites([{ Delete: deleteSessionRegistration }, { Update: updateSessionCount }]);
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  private async putSafeResource(): Promise<SessionRegistration> {
+    const { sessionId, userId } = this.registration;
+    const isValid = await this.validateRegistration(sessionId, userId);
+
+    if (!isValid) throw new RCError("User can't sign up for this session!");
+
+    try {
+      const putSessionRegistration = { TableName: DDB_TABLES.registrations, Item: this.registration };
+
+      const updateSessionCount = {
+        TableName: DDB_TABLES.sessions,
+        Key: { sessionId },
+        UpdateExpression: 'ADD numberOfParticipants :one',
+        ExpressionAttributeValues: {
+          ':one': 1
+        }
+      };
+
+      await ddb.transactWrites([{ Put: putSessionRegistration }, { Update: updateSessionCount }]);
+
+      return this.registration;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  private async validateRegistration(sessionId: string, userId: string) {
+    const session: Session = new Session(await ddb.get({ TableName: DDB_TABLES.sessions, Key: { sessionId } }));
+
+    if (!session.requiresRegistration) throw new RCError("User can't sign up for this session!");
+    if (session.isFull()) throw new RCError('Session is full! Refresh your page.');
+
+    const userRegistrations: SessionRegistration[] = await this.getUsersRegistrations(userId);
+
+    if (!userRegistrations.length) return true;
+
+    const sessions: Session[] = (
+      await ddb.batchGet(
+        DDB_TABLES.sessions,
+        userRegistrations.map(ur => ({ sessionId: ur.sessionId }))
+      )
+    ).map(s => new Session(s));
+
+    // make sure user doesn't have overlapping schedule
+    const validSessions: Session[] = sessions.filter(s => {
+      const sessionStartDate = s.calcDatetimeWithoutTimezone(s.startsAt);
+      const sessionEndDate = s.calcDatetimeWithoutTimezone(s.endsAt);
+
+      const targetSessionStart = session.calcDatetimeWithoutTimezone(session.startsAt);
+      const targetSessionEnd = session.calcDatetimeWithoutTimezone(session.endsAt);
+
+      // it's easier to prove a session is valid than it is to prove it's invalid. (1 vs 5 conditional checks)
+      return sessionStartDate >= targetSessionEnd || sessionEndDate <= targetSessionStart;
+    });
+
+    if (sessions.length !== validSessions.length)
+      throw new RCError('You have 1 or more sessions during this time period.');
+
+    return true;
+  }
+
+  private async getUsersRegistrations(userId: string): Promise<SessionRegistration[]> {
+    try {
+      const registrationsOfUser = await ddb.query({
+        TableName: DDB_TABLES.registrations,
+        IndexName: 'userId-sessionId-index',
+        KeyConditionExpression: 'userId = :userId',
+        ExpressionAttributeValues: { ':userId': userId }
+      });
+      return registrationsOfUser.map(s => new SessionRegistration(s));
+    } catch (error) {
+      throw new RCError('Could not load registrations for this user');
+    }
+  }
+}

--- a/back-end/src/handlers/registrations.ts
+++ b/back-end/src/handlers/registrations.ts
@@ -41,7 +41,7 @@ class SessionRegistrations extends ResourceController {
       throw new RCError('User not found');
     }
 
-    if (!this.resourceId) return;
+    if (!this.resourceId || this.httpMethod === 'POST') return;
 
     try {
       this.registration = new SessionRegistration(
@@ -75,10 +75,8 @@ class SessionRegistrations extends ResourceController {
   protected async postResources(): Promise<any> {
     // @todo configurations.canSignUpForSessions()
 
-    if (!this.body.sessionId) throw new RCError('Missing session ID!');
-
     this.registration = new SessionRegistration({
-      sessionId: this.body.sessionId,
+      sessionId: this.resourceId,
       userId: this.principalId,
       registrationDateInMs: new Date().getTime()
     });

--- a/back-end/src/handlers/rooms.ts
+++ b/back-end/src/handlers/rooms.ts
@@ -1,0 +1,120 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Room } from '../models/room.model';
+import { VenueLinked } from '../models/venue.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  rooms: process.env.DDB_TABLE_rooms,
+  venues: process.env.DDB_TABLE_venues
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Rooms(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Rooms extends ResourceController {
+  user: User;
+  room: Room;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'roomId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.room = new Room(await ddb.get({ TableName: DDB_TABLES.rooms, Key: { roomId: this.resourceId } }));
+    } catch (err) {
+      throw new RCError('Room not found');
+    }
+  }
+
+  protected async getResource(): Promise<Room> {
+    return this.room;
+  }
+
+  protected async putResource(): Promise<Room> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Room(this.room);
+    this.room.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Room> {
+    const errors = this.room.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    this.room.venue = new VenueLinked(
+      await ddb.get({ TableName: DDB_TABLES.venues, Key: { venueId: this.room.venue.venueId } })
+    );
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.rooms, Item: this.room };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(roomId)';
+      await ddb.put(putParams);
+
+      return this.room;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.rooms, Key: { roomId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Room> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.room = new Room(this.body);
+    this.room.roomId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<Room[]> {
+    try {
+      const rooms = (await ddb.scan({ TableName: DDB_TABLES.rooms })).map((x: Room) => new Room(x));
+
+      const filteredRooms = this.queryParams.venue
+        ? rooms.filter(x => x.venue.venueId === this.queryParams.venue)
+        : rooms;
+
+      const sortedRooms = filteredRooms.sort((a, b) => a.name.localeCompare(b.name));
+
+      return sortedRooms;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/handlers/sessions.ts
+++ b/back-end/src/handlers/sessions.ts
@@ -1,0 +1,134 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Session } from '../models/session.model';
+import { SpeakerLinked } from '../models/speaker.model';
+import { RoomLinked } from '../models/room.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  sessions: process.env.DDB_TABLE_sessions,
+  rooms: process.env.DDB_TABLE_rooms,
+  speakers: process.env.DDB_TABLE_speakers
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Sessions(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Sessions extends ResourceController {
+  user: User;
+  session: Session;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'sessionId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.session = new Session(
+        await ddb.get({ TableName: DDB_TABLES.sessions, Key: { sessionId: this.resourceId } })
+      );
+    } catch (err) {
+      throw new RCError('Session not found');
+    }
+  }
+
+  protected async getResource(): Promise<Session> {
+    return this.session;
+  }
+
+  protected async putResource(): Promise<Session> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Session(this.session);
+    this.session.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Session> {
+    const errors = this.session.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    this.session.room = new RoomLinked(
+      await ddb.get({ TableName: DDB_TABLES.rooms, Key: { roomId: this.session.room.roomId } })
+    );
+
+    this.session.speakers = (
+      await ddb.batchGet(
+        DDB_TABLES.speakers,
+        this.session.speakers?.map(speakerId => ({ speakerId })),
+        true
+      )
+    ).map(s => new SpeakerLinked(s));
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.sessions, Item: this.session };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(sessionId)';
+      await ddb.put(putParams);
+
+      return this.session;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.sessions, Key: { sessionId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Session> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.session = new Session(this.body);
+    this.session.sessionId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<Session[]> {
+    try {
+      const sessions = (await ddb.scan({ TableName: DDB_TABLES.sessions })).map((x: Session) => new Session(x));
+
+      const filtertedSessions = sessions.filter(
+        x =>
+          (!this.queryParams.speaker || x.speakers.filter(x => x).includes(this.queryParams.speaker)) &&
+          (!this.queryParams.room || x.room.roomId === this.queryParams.room)
+      );
+
+      const sortedSessions = filtertedSessions.sort((a, b) => a.startsAt.localeCompare(b.startsAt));
+
+      return sortedSessions;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/handlers/speakers.ts
+++ b/back-end/src/handlers/speakers.ts
@@ -1,0 +1,125 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Speaker } from '../models/speaker.model';
+import { OrganizationLinked } from '../models/organization.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = {
+  users: process.env.DDB_TABLE_users,
+  speakers: process.env.DDB_TABLE_speakers,
+  organizations: process.env.DDB_TABLE_organizations
+};
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Speakers(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Speakers extends ResourceController {
+  user: User;
+  speaker: Speaker;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'speakerId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.speaker = new Speaker(
+        await ddb.get({ TableName: DDB_TABLES.speakers, Key: { speakerId: this.resourceId } })
+      );
+    } catch (err) {
+      throw new RCError('Speaker not found');
+    }
+  }
+
+  protected async getResource(): Promise<Speaker> {
+    return this.speaker;
+  }
+
+  protected async putResource(): Promise<Speaker> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Speaker(this.speaker);
+    this.speaker.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Speaker> {
+    const errors = this.speaker.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    this.speaker.organization = new OrganizationLinked(
+      await ddb.get({
+        TableName: DDB_TABLES.organizations,
+        Key: { organizationId: this.speaker.organization.organizationId }
+      })
+    );
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.speakers, Item: this.speaker };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(speakerId)';
+      await ddb.put(putParams);
+
+      return this.speaker;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.speakers, Key: { speakerId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Speaker> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.speaker = new Speaker(this.body);
+    this.speaker.speakerId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<Speaker[]> {
+    try {
+      const speakers = (await ddb.scan({ TableName: DDB_TABLES.speakers })).map((x: Speaker) => new Speaker(x));
+
+      const filteredSpeakers = this.queryParams.organization
+        ? speakers.filter(x => x.organization.organizationId === this.queryParams.organization)
+        : speakers;
+
+      const sortedSpeakers = filteredSpeakers.sort((a, b) => a.name.localeCompare(b.name));
+
+      return sortedSpeakers;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/handlers/venues.ts
+++ b/back-end/src/handlers/venues.ts
@@ -1,0 +1,105 @@
+///
+/// IMPORTS
+///
+
+import { DynamoDB, RCError, ResourceController } from 'idea-aws';
+
+import { Venue } from '../models/venue.model';
+import { User } from '../models/user.model';
+
+///
+/// CONSTANTS, ENVIRONMENT VARIABLES, HANDLER
+///
+
+const PROJECT = process.env.PROJECT;
+
+const DDB_TABLES = { users: process.env.DDB_TABLE_users, venues: process.env.DDB_TABLE_venues };
+
+const ddb = new DynamoDB();
+
+export const handler = (ev: any, _: any, cb: any) => new Venues(ev, cb).handleRequest();
+
+///
+/// RESOURCE CONTROLLER
+///
+
+class Venues extends ResourceController {
+  user: User;
+  venue: Venue;
+
+  constructor(event: any, callback: any) {
+    super(event, callback, { resourceId: 'venueId' });
+  }
+
+  protected async checkAuthBeforeRequest(): Promise<void> {
+    try {
+      this.user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId: this.principalId } }));
+    } catch (err) {
+      throw new RCError('User not found');
+    }
+
+    if (!this.resourceId) return;
+
+    try {
+      this.venue = new Venue(await ddb.get({ TableName: DDB_TABLES.venues, Key: { venueId: this.resourceId } }));
+    } catch (err) {
+      throw new RCError('Venue not found');
+    }
+  }
+
+  protected async getResource(): Promise<Venue> {
+    return this.venue;
+  }
+
+  protected async putResource(): Promise<Venue> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    const oldResource = new Venue(this.venue);
+    this.venue.safeLoad(this.body, oldResource);
+
+    return await this.putSafeResource();
+  }
+  private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Venue> {
+    const errors = this.venue.validate();
+    if (errors.length) throw new RCError(`Invalid fields: ${errors.join(', ')}`);
+
+    try {
+      const putParams: any = { TableName: DDB_TABLES.venues, Item: this.venue };
+      if (opts.noOverwrite) putParams.ConditionExpression = 'attribute_not_exists(venueId)';
+      await ddb.put(putParams);
+
+      return this.venue;
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+
+  protected async deleteResource(): Promise<void> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    try {
+      await ddb.delete({ TableName: DDB_TABLES.venues, Key: { venueId: this.resourceId } });
+    } catch (err) {
+      throw new RCError('Delete failed');
+    }
+  }
+
+  protected async postResources(): Promise<Venue> {
+    if (!this.user.permissions.canManageContents) throw new RCError('Unauthorized');
+
+    this.venue = new Venue(this.body);
+    this.venue.venueId = await ddb.IUNID(PROJECT);
+
+    return await this.putSafeResource({ noOverwrite: true });
+  }
+
+  protected async getResources(): Promise<Venue[]> {
+    try {
+      return (await ddb.scan({ TableName: DDB_TABLES.venues }))
+        .map((x: Venue) => new Venue(x))
+        .sort((a, b) => a.name.localeCompare(b.name));
+    } catch (err) {
+      throw new RCError('Operation failed');
+    }
+  }
+}

--- a/back-end/src/models/communication.model.ts
+++ b/back-end/src/models/communication.model.ts
@@ -1,0 +1,56 @@
+import { epochISOString, isEmpty, Resource } from 'idea-toolbox';
+
+export class Communication extends Resource {
+  /**
+   * The communication ID.
+   */
+  communicationId: string;
+  /**
+   * The title of the communication.
+   */
+  title: string;
+  /**
+   * The content of the communication.
+   */
+  content: string;
+  /**
+   * The date of publishing for the communication.
+   */
+  publishedAt: epochISOString;
+  /**
+   * The URI for an image to display on this communication.
+   */
+  imageURI: string;
+
+  // @todo do we add more stuff here? Push notifications, links, etc...
+
+  load(x: any): void {
+    super.load(x);
+    this.communicationId = this.clean(x.communicationId, String);
+    this.title = this.clean(x.title, String);
+    this.content = this.clean(x.content, String);
+    this.publishedAt = this.clean(x.publishedAt, t => new Date(t).toISOString(), new Date().toISOString());
+    this.imageURI = this.clean(x.imageURI, String);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.communicationId = safeData.communicationId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.title)) e.push('title');
+    if (isEmpty(this.content)) e.push('content');
+    if (isEmpty(this.publishedAt, 'date')) e.push('publishedAt');
+    return e;
+  }
+}
+
+// @todo check if this is needed
+export class CommunicationWithMarker extends Communication {
+  hasBeenReadByUser?: boolean;
+
+  load(x: any): void {
+    super.load(x);
+    if (x.hasBeenReadByUser) this.hasBeenReadByUser = true;
+  }
+}

--- a/back-end/src/models/connection.model.ts
+++ b/back-end/src/models/connection.model.ts
@@ -1,0 +1,38 @@
+import { Resource } from 'idea-toolbox';
+import { User } from './user.model';
+
+export class Connection extends Resource {
+  /**
+   * The ID of the connection.
+   */
+  connectionId: string;
+  /**
+   * The user ID requesting a connection.
+   */
+  requesterId: string;
+  /**
+   * The target user ID of the connection.
+   */
+  targetId: string;
+  /**
+   * Wether the connection request is pending or not.
+   */
+  isPending?: boolean;
+
+  load(x: any): void {
+    super.load(x);
+    this.connectionId = this.clean(x.connectionId, String);
+    this.requesterId = this.clean(x.requesterId, String);
+    this.targetId = this.clean(x.targetId, String);
+    if (x.isPending) this.isPending = true;
+  }
+}
+
+export class ConnectionWithUserData extends Connection {
+  userProfile: User;
+
+  load(x: any): void {
+    super.load(x);
+    this.userProfile = new User(x.userProfile);
+  }
+}

--- a/back-end/src/models/organization.model.ts
+++ b/back-end/src/models/organization.model.ts
@@ -1,0 +1,66 @@
+import { isEmpty, Resource } from 'idea-toolbox';
+
+export class Organization extends Resource {
+  /**
+   * The organization ID.
+   */
+  organizationId: string;
+  /**
+   * The name of the organization.
+   */
+  name: string;
+  /**
+   * The URI for an image describing the organization
+   */
+  imageURI: string;
+  /**
+   * A description of the organization.
+   */
+  description: string;
+  /**
+   * The organization's website.
+   */
+  website: string;
+  /**
+   * The organization's contact email.
+   */
+  contactEmail: string;
+  /**
+   * A link to perform a contact action.
+   */
+  contactAction: string; // @todo check this
+
+  load(x: any): void {
+    super.load(x);
+    this.organizationId = this.clean(x.organizationId, String);
+    this.name = this.clean(x.name, String);
+    this.imageURI = this.clean(x.imageURI, String);
+    this.description = this.clean(x.description, String);
+    this.website = this.clean(x.website, String);
+    this.contactEmail = this.clean(x.contactEmail, String);
+    this.contactAction = this.clean(x.contactAction, String);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.organizationId = safeData.organizationId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.name)) e.push('name');
+    if (this.website && isEmpty(this.website, 'url')) e.push('website');
+    if (this.contactEmail && isEmpty(this.contactEmail, 'email')) e.push('contactEmail');
+    return e;
+  }
+}
+
+// @todo check this
+export class OrganizationLinked extends Resource {
+  organizationId: string;
+  name: string;
+
+  load(x: any): void {
+    super.load(x);
+    this.organizationId = this.clean(x.organizationId, String);
+    this.name = this.clean(x.name, String);
+  }
+}

--- a/back-end/src/models/room.model.ts
+++ b/back-end/src/models/room.model.ts
@@ -1,0 +1,68 @@
+import { isEmpty, Resource } from 'idea-toolbox';
+
+import { VenueLinked } from './venue.model';
+
+export class Room extends Resource {
+  /**
+   * The room ID.
+   */
+  roomId: string;
+  /**
+   * The name of the room.
+   */
+  name: string;
+  /**
+   * The venue where this room is located
+   */
+  venue: VenueLinked;
+  /**
+   * The room's internal location.
+   */
+  internalLocation: string;
+  /**
+   * A description for the room.
+   */
+  description: string;
+  /**
+   * An URI for an image of the room.
+   */
+  imageURI: string;
+  /**
+   * An URI for a plan of the room.
+   */
+  planImageURI: string;
+
+  load(x: any): void {
+    super.load(x);
+    this.roomId = this.clean(x.roomId, String);
+    this.name = this.clean(x.name, String);
+    this.venue = typeof x.venue === 'string' ? new VenueLinked({ venueId: x.venue }) : new VenueLinked(x.venue);
+    this.internalLocation = this.clean(x.internalLocation, String);
+    this.description = this.clean(x.description, String);
+    this.imageURI = this.clean(x.imageURI, String);
+    this.planImageURI = this.clean(x.planImageURI, String);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.roomId = safeData.roomId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.name)) e.push('name');
+    if (!this.venue.venueId) e.push('venue');
+    return e;
+  }
+}
+
+export class RoomLinked extends Resource {
+  roomId: string;
+  name: string;
+  venue: VenueLinked;
+
+  load(x: any): void {
+    super.load(x);
+    this.roomId = this.clean(x.roomId, String);
+    this.name = this.clean(x.name, String);
+    this.venue = new VenueLinked(x.venue);
+  }
+}

--- a/back-end/src/models/session.model.ts
+++ b/back-end/src/models/session.model.ts
@@ -48,11 +48,11 @@ export class Session extends Resource {
   /**
    * The session's speakrs.
    */
-  speakers: SpeakerLinked[]; // @todo we changed this to a single array. Check consequences
+  speakers: SpeakerLinked[];
   /**
    * The number of participants currently registered
    */
-  numberOfParticipants: number; // @todo should this be calculated?
+  numberOfParticipants: number;
   /**
    * The limit of participants for this session.
    */

--- a/back-end/src/models/session.model.ts
+++ b/back-end/src/models/session.model.ts
@@ -1,0 +1,149 @@
+import { isEmpty, Resource } from 'idea-toolbox';
+
+import { RoomLinked } from './room.model';
+import { SpeakerLinked } from './speaker.model';
+
+/**
+ * YYYY-MM-DDTHH:MM, without timezone. // @todo do we need this?
+ */
+type datetime = string;
+
+export class Session extends Resource {
+  /**
+   * The session ID.
+   */
+  sessionId: string;
+  /**
+   * The session's code.
+   */
+  code: string;
+  /**
+   * The session's name.
+   */
+  name: string;
+  /**
+   * The session's description.
+   */
+  description: string;
+  /**
+   * The type of session.
+   */
+  type: SessionType;
+  /**
+   * The session's start date.
+   */
+  startsAt: datetime;
+  /**
+   * The session's end date.
+   */
+  endsAt: datetime;
+  /**
+   * The session's duration in minutes.
+   */
+  durationMinutes: number;
+  /**
+   * The room where the session will take place.
+   */
+  room: RoomLinked;
+  /**
+   * The session's speakrs.
+   */
+  speakers: SpeakerLinked[]; // @todo we changed this to a single array. Check consequences
+  /**
+   * The number of participants currently registered
+   */
+  numberOfParticipants: number; // @todo should this be calculated?
+  /**
+   * The limit of participants for this session.
+   */
+  limitOfParticipants: number;
+  /**
+   * Wether the sessions requires registration.
+   */
+  requiresRegistration: boolean;
+
+  load(x: any): void {
+    super.load(x);
+    this.sessionId = this.clean(x.sessionId, String);
+    this.code = this.clean(x.code, String);
+    this.name = this.clean(x.name, String);
+    this.description = this.clean(x.description, String);
+    this.type = this.clean(x.type, String) as SessionType;
+    this.startsAt = this.clean(x.startsAt, t => this.calcDatetimeWithoutTimezone(t));
+    this.durationMinutes = this.clean(x.durationMinutes, Number);
+    const endsAt = new Date(this.startsAt);
+    endsAt.setMinutes(endsAt.getMinutes() + this.durationMinutes);
+    this.endsAt = this.calcDatetimeWithoutTimezone(endsAt);
+    this.room = typeof x.room === 'string' ? new RoomLinked({ roomId: x.room }) : new RoomLinked(x.room);
+    this.speakers = this.cleanArray(x.speakers, x => new SpeakerLinked(x));
+    this.numberOfParticipants = this.clean(x.numberOfParticipants, Number, 0);
+    this.limitOfParticipants = this.clean(x.limitOfParticipants, Number);
+    this.requiresRegistration = Object.keys(IndividualSessionType).includes(this.type);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.sessionId = safeData.sessionId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.name)) e.push('name');
+    if (!Object.keys(SessionType).includes(this.type)) e.push('type');
+    if (isEmpty(this.startsAt, 'date')) e.push('startsAt');
+    if (isEmpty(this.durationMinutes)) e.push('durationMinutes');
+    if (!this.room.roomId) e.push('room');
+    if (!this.speakers?.length) e.push('speakers');
+    return e;
+  }
+
+  // @todo add a method to check if a user/speaker is in the session or not
+
+  calcDatetimeWithoutTimezone(dateToFormat: Date | string | number): datetime {
+    const date = new Date(dateToFormat);
+    return new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+  }
+
+  isFull(): boolean {
+    return this.numberOfParticipants >= this.limitOfParticipants;
+  }
+}
+
+// @todo don't have three enums...
+// @todo check if any is missing or we need to add.
+export enum CommonSessionType {
+  OPENING = 'OPENING',
+  KEYNOTE = 'KEYNOTE',
+  MORNING = 'MORNING',
+  POSTER = 'POSTER',
+  EXPO = 'EXPO',
+  CANDIDATES = 'CANDIDATES',
+  HARVESTING = 'HARVESTING',
+  CLOSING = 'CLOSING',
+  OTHER = 'OTHER'
+}
+
+export enum IndividualSessionType {
+  DISCUSSION = 'DISCUSSION',
+  TALK = 'TALK',
+  IGNITE = 'IGNITE',
+  CAMPFIRE = 'CAMPFIRE',
+  IDEAS = 'IDEAS',
+  INCUBATOR = 'INCUBATOR'
+}
+
+export enum SessionType {
+  OPENING = 'OPENING',
+  KEYNOTE = 'KEYNOTE',
+  MORNING = 'MORNING',
+  POSTER = 'POSTER',
+  EXPO = 'EXPO',
+  CANDIDATES = 'CANDIDATES',
+  HARVESTING = 'HARVESTING',
+  CLOSING = 'CLOSING',
+  DISCUSSION = 'DISCUSSION',
+  TALK = 'TALK',
+  IGNITE = 'IGNITE',
+  CAMPFIRE = 'CAMPFIRE',
+  IDEAS = 'IDEAS',
+  INCUBATOR = 'INCUBATOR',
+  OTHER = 'OTHER'
+}

--- a/back-end/src/models/sessionRegistration.model.ts
+++ b/back-end/src/models/sessionRegistration.model.ts
@@ -1,0 +1,23 @@
+import { Resource } from 'idea-toolbox';
+
+export class SessionRegistration extends Resource {
+  /**
+   * The session ID.
+   */
+  sessionId: string;
+  /**
+   * The user's ID.
+   */
+  userId: string;
+  /**
+   * The date of the registration.
+   */
+  registrationDateInMs: number;
+
+  load(x: any): void {
+    super.load(x);
+    this.sessionId = this.clean(x.sessionId, String);
+    this.userId = this.clean(x.userId, String);
+    this.registrationDateInMs = this.clean(x.registrationDateInMs, t => new Date(t).getTime());
+  }
+}

--- a/back-end/src/models/speaker.model.ts
+++ b/back-end/src/models/speaker.model.ts
@@ -1,0 +1,80 @@
+import { isEmpty, Resource } from 'idea-toolbox';
+
+import { OrganizationLinked } from './organization.model';
+
+export class Speaker extends Resource {
+  /**
+   * The speaker ID.
+   */
+  speakerId: string;
+  /**
+   * The name of the speaker.
+   */
+  name: string;
+  /**
+   * The URI for the speaker's profile picture.
+   */
+  imageURI: string;
+  /**
+   * The title of the speaker.
+   */
+  title: string;
+  /**
+   * A description of the speaker.
+   */
+  description: string;
+  /**
+   * The speaker's contact email.
+   */
+  contactEmail: string;
+  /**
+   * The speaker's organization.
+   */
+  organization: OrganizationLinked;
+
+  static getRole(speaker: Speaker | SpeakerLinked): string {
+    return speaker.organization.name || speaker.title
+      ? [speaker.organization.name, speaker.title].filter(x => x).join(', ')
+      : '';
+  }
+
+  load(x: any): void {
+    super.load(x);
+    this.speakerId = this.clean(x.speakerId, String);
+    this.name = this.clean(x.name, String);
+    this.imageURI = this.clean(x.imageURI, String);
+    this.title = this.clean(x.title, String);
+    this.description = this.clean(x.description, String);
+    this.contactEmail = this.clean(x.contactEmail, String);
+    this.organization =
+      typeof x.organization === 'string'
+        ? new OrganizationLinked({ organizationId: x.organization })
+        : new OrganizationLinked(x.organization);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.speakerId = safeData.speakerId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.name)) e.push('name');
+    if (this.contactEmail && isEmpty(this.contactEmail, 'email')) e.push('contactEmail');
+    if (!this.organization.organizationId) e.push('organization');
+    return e;
+  }
+}
+
+export class SpeakerLinked extends Resource {
+  speakerId: string;
+  name: string;
+  title: string;
+  organization: OrganizationLinked;
+
+  load(x: any): void {
+    super.load(x);
+    this.speakerId = this.clean(x.speakerId, String);
+    this.name = this.clean(x.name, String);
+    this.title = this.clean(x.title, String);
+    this.organization = new OrganizationLinked(x.organization);
+  }
+}

--- a/back-end/src/models/user.model.ts
+++ b/back-end/src/models/user.model.ts
@@ -1,6 +1,7 @@
 import { Resource, Suggestion, epochISOString } from 'idea-toolbox';
 
 import { EventSpotAttached } from './eventSpot.model';
+import { Speaker } from './speaker.model';
 
 export class User extends Resource {
   /**
@@ -152,6 +153,10 @@ export class User extends Resource {
     return this.authService !== AuthServices.ESN_ACCOUNTS;
   }
 
+  isSpeaker(speaker: Speaker) {
+    return speaker.speakerId === this.userId;
+  }
+
   isGalaxyInfoValid(): boolean {
     if (this.isExternal()) return true;
     return this.sectionName !== 'Unknown' && this.sectionCountry !== 'Unknown';
@@ -219,5 +224,16 @@ export class UserPermissions {
     this.canManageContents = Boolean(x.canManageContents);
     // as last, to change any other attribute in case it's `true`
     this.isAdmin = Boolean(x._isAdmin);
+  }
+}
+
+export class UserFavoriteSession extends Resource {
+  userId: string;
+  sessionId: string;
+
+  load(x: any): void {
+    super.load(x);
+    this.userId = this.clean(x.userId, String);
+    this.sessionId = this.clean(x.sessionId, String);
   }
 }

--- a/back-end/src/models/venue.model.ts
+++ b/back-end/src/models/venue.model.ts
@@ -1,0 +1,70 @@
+import { Resource, isEmpty } from 'idea-toolbox';
+
+export class Venue extends Resource {
+  /**
+   * The ID of the venue.
+   */
+  venueId: string;
+  /**
+   * The name of the venue.
+   */
+  name: string;
+  /**
+   * The image URI for a picture of the venue.
+   */
+  imageURI: string;
+  /**
+   * The venue's address.
+   */
+  address: string;
+  /**
+   * A description of the venue.
+   */
+  description: string;
+  /**
+   * The venue's longitude coordinates.
+   */
+  longitude: number;
+  /**
+   * The venue's latitude coordinates.
+   */
+  latitude: number;
+
+  static getCoordinates(venue: Venue): [number, number] {
+    return [venue.longitude, venue.latitude];
+  }
+
+  load(x: any): void {
+    super.load(x);
+    this.venueId = this.clean(x.venueId, String);
+    this.name = this.clean(x.name, String);
+    this.imageURI = this.clean(x.imageURI, String);
+    this.address = this.clean(x.address, String);
+    this.description = this.clean(x.description, String);
+    this.longitude = this.clean(x.longitude, Number);
+    this.latitude = this.clean(x.latitude, Number);
+  }
+  safeLoad(newData: any, safeData: any): void {
+    super.safeLoad(newData, safeData);
+    this.venueId = safeData.venueId;
+  }
+  validate(): string[] {
+    const e = super.validate();
+    if (isEmpty(this.name)) e.push('name');
+    if (isEmpty(this.address)) e.push('address');
+    if (isEmpty(this.longitude)) e.push('longitude');
+    if (isEmpty(this.latitude)) e.push('latitude');
+    return e;
+  }
+}
+
+export class VenueLinked extends Resource {
+  venueId: string;
+  name: string;
+
+  load(x: any): void {
+    super.load(x);
+    this.venueId = this.clean(x.venueId, String);
+    this.name = this.clean(x.name, String);
+  }
+}

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -42,6 +42,8 @@ tags:
     description: The organizations of the event
   - name: Rooms
     description: The rooms of the event
+  - name: Speakers
+    description: The speakers of the event
 
 paths:
   /status:
@@ -850,6 +852,94 @@ paths:
           $ref: '#/components/responses/Room'
         400:
           $ref: '#/components/responses/BadParameters'
+  /speakers:
+    get:
+      summary: Get the speakers
+      tags: [Speakers]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: organization
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Speakers'
+    post:
+      summary: Insert a new speaker
+      description: Requires to be Admin.
+      tags: [Speakers]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Speaker
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Speaker'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /speakers/{speakerId}:
+    get:
+      summary: Get a speaker
+      tags: [Speakers]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: speakerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Speaker'
+    put:
+      summary: Edit a speaker
+      description: Requires to be Admin.
+      tags: [Speakers]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: speakerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Speaker
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Speaker'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete a speaker
+      description: Requires to be Admin.
+      tags: [Speakers]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: speakerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -878,6 +968,9 @@ components:
       type: object
       additionalProperties: {}
     Room:
+      type: object
+      additionalProperties: {}
+    Speaker:
       type: object
       additionalProperties: {}
 
@@ -1004,6 +1097,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Room'
+    Speaker:
+      description: Speaker
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Speaker'
+    Speakers:
+      description: Speaker[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Speaker'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -239,15 +239,17 @@ paths:
               properties:
                 action:
                   type: string
-                  enum:
-                    [
+                  enum: [
                       GET_AVATAR_UPLOAD_URL,
                       REGISTER_TO_EVENT,
                       CHANGE_PERMISSIONS,
                       GET_PROOF_OF_PAYMENT,
                       PUT_PROOF_OF_PAYMENT_START,
                       PUT_PROOF_OF_PAYMENT_END,
-                      GET_INVOICE
+                      GET_INVOICE,
+                      ADD_FAVORITE_SESSION
+                      REMOVE_FAVORITE_SESSION
+                      GET_FAVORITE_SESSIONS
                     ]
                 registrationForm:
                   type: number
@@ -261,6 +263,9 @@ paths:
                 fileURI:
                   type: string
                   description: (PUT_PROOF_OF_PAYMENT_END)
+                sessionId:
+                  type: string
+                  description: (ADD_FAVORITE_SESSION, REMOVE_FAVORITE_SESSION)
       responses:
         200:
           $ref: '#/components/responses/User'

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -40,6 +40,8 @@ tags:
     description: The event's communications and announcements.
   - name: Organizations
     description: The organizations of the event
+  - name: Rooms
+    description: The rooms of the event
 
 paths:
   /status:
@@ -760,6 +762,94 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /rooms:
+    get:
+      summary: Get the rooms
+      tags: [Rooms]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: venue
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Rooms'
+    post:
+      summary: Insert a new room
+      description: Requires to be content manager
+      tags: [Rooms]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Room
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Room'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /rooms/{roomId}:
+    get:
+      summary: Get a room
+      tags: [Rooms]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: roomId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Room'
+    put:
+      summary: Edit a room
+      description: Requires to be content manager
+      tags: [Rooms]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: roomId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Room
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Room'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete a room
+      description: Requires to be content manager
+      tags: [Rooms]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: roomId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Room'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -785,6 +875,9 @@ components:
       type: object
       additionalProperties: {}
     Organization:
+      type: object
+      additionalProperties: {}
+    Room:
       type: object
       additionalProperties: {}
 
@@ -895,6 +988,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Organization'
+    Room:
+      description: Room
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Room'
+    Rooms:
+      description: Room[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Room'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -34,6 +34,8 @@ tags:
     description: The event-related actions
   - name: UsefulLinks
     description: The useful links available to the users to explore more contents
+  - name: Venues
+    description: The venues of the event
 
 paths:
   /status:
@@ -477,6 +479,89 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /venues:
+    get:
+      summary: Get the venues
+      tags: [Venues]
+      security:
+        - AuthFunction: []
+      responses:
+        200:
+          $ref: '#/components/responses/Venues'
+    post:
+      summary: Insert a new venue
+      description: Requires to be content manager
+      tags: [Venues]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Venue
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Venue'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /venues/{venueId}:
+    get:
+      summary: Get a venue
+      tags: [Venues]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: venueId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Venue'
+    put:
+      summary: Edit a venue
+      description: Requires to be content manager
+      tags: [Venues]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: venueId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Venue
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Venue'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete a venue
+      description: Requires to be content manager
+      tags: [Venues]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: venueId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -493,6 +578,15 @@ components:
       type: object
       additionalProperties: {}
     UsefulLink:
+      type: object
+      additionalProperties: {}
+    Venue:
+      type: object
+      additionalProperties: {}
+    Communication:
+      type: object
+      additionalProperties: {}
+    Organization:
       type: object
       additionalProperties: {}
 
@@ -556,6 +650,21 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/UsefulLink'
+    Venue:
+      description: Venue
+      content:
+        application/json:
+          schema:
+            type: object
+            $ref: '#/components/schemas/Venue'
+    Venues:
+      description: Venue[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Venue'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -44,6 +44,8 @@ tags:
     description: The rooms of the event
   - name: Speakers
     description: The speakers of the event
+  - name: Sessions
+    description: The sessions of the event
 
 paths:
   /status:
@@ -868,7 +870,7 @@ paths:
           $ref: '#/components/responses/Speakers'
     post:
       summary: Insert a new speaker
-      description: Requires to be Admin.
+      description: Requires to be content manager
       tags: [Speakers]
       security:
         - AuthFunction: []
@@ -901,7 +903,7 @@ paths:
           $ref: '#/components/responses/Speaker'
     put:
       summary: Edit a speaker
-      description: Requires to be Admin.
+      description: Requires to be content manager
       tags: [Speakers]
       security:
         - AuthFunction: []
@@ -925,12 +927,104 @@ paths:
           $ref: '#/components/responses/BadParameters'
     delete:
       summary: Delete a speaker
-      description: Requires to be Admin.
+      description: Requires to be content manager
       tags: [Speakers]
       security:
         - AuthFunction: []
       parameters:
         - name: speakerId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /sessions:
+    get:
+      summary: Get the sessions
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: speaker
+          in: query
+          schema:
+            type: string
+        - name: venue
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Sessions'
+    post:
+      summary: Insert a new session
+      description: Requires to be content manager
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Session
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Session'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /sessions/{sessionId}:
+    get:
+      summary: Get a session
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Session'
+    put:
+      summary: Edit a session
+      description: Requires to be content manager
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Session
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Session'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete a session
+      description: Requires to be content manager
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
           in: path
           required: true
           schema:
@@ -971,6 +1065,9 @@ components:
       type: object
       additionalProperties: {}
     Speaker:
+      type: object
+      additionalProperties: {}
+    Session:
       type: object
       additionalProperties: {}
 
@@ -1113,6 +1210,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Speaker'
+    Session:
+      description: Session
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Session'
+    Sessions:
+      description: Session[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Session'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -1053,23 +1053,6 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/Registrations'
-    post:
-      summary: Create a new session registration
-      tags: [Sessions]
-      security:
-        - AuthFunction: []
-      requestBody:
-        required: true
-        description: Registration
-        content:
-          application/json:
-            schema:
-              type: object
-      responses:
-        200:
-          $ref: '#/components/responses/Registration'
-        400:
-          $ref: '#/components/responses/BadParameters'
   /registrations/{sessionId}:
     get:
       summary: Get a session registration
@@ -1085,6 +1068,29 @@ paths:
       responses:
         200:
           $ref: '#/components/responses/Registration'
+    post:
+      summary: Create a new session registration
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Registration
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Registration'
+        400:
+          $ref: '#/components/responses/BadParameters'
     delete:
       summary: Delete a registration
       description: Requires to be Admin or the registered user.

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -1034,6 +1034,69 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /registrations:
+    get:
+      summary: Get the registrations for a user or for a session
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: query
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Registrations'
+    post:
+      summary: Create a new session registration
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Registration
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Registration'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /registrations/{sessionId}:
+    get:
+      summary: Get a session registration
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Registration'
+    delete:
+      summary: Delete a registration
+      description: Requires to be Admin or the registered user.
+      tags: [Sessions]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -1068,6 +1131,9 @@ components:
       type: object
       additionalProperties: {}
     Session:
+      type: object
+      additionalProperties: {}
+    Registration:
       type: object
       additionalProperties: {}
 
@@ -1226,6 +1292,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Session'
+    Registration:
+      description: Registration
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Registration'
+    Registrations:
+      description: Registration[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Registration'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -36,6 +36,8 @@ tags:
     description: The useful links available to the users to explore more contents
   - name: Venues
     description: The venues of the event
+  - name: Communications
+    description: The event's communications and announcements.
 
 paths:
   /status:
@@ -562,6 +564,117 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /communications:
+    get:
+      summary: Get the communications
+      tags: [Communications]
+      security:
+        - AuthFunction: []
+      responses:
+        200:
+          $ref: '#/components/responses/Communications'
+    post:
+      summary: Insert a new communication
+      description: Requires to be content manager
+      tags: [Communications]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Communication
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Communication'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /communications/{communicationId}:
+    get:
+      summary: Get a communication
+      tags: [Communications]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: communicationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Communication'
+    put:
+      summary: Edit a communication
+      description: Requires to be content manager
+      tags: [Communications]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: communicationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Communication
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Communication'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    patch:
+      summary: Actions on a communication
+      tags: [Communications, Users]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: communicationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                action:
+                  type: string
+                  enum:
+                    - MARK_AS_READ
+                    - MARK_AS_UNREAD
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete a communication
+      description: Requires to be content manager
+      tags: [Communications]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: communicationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -665,6 +778,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Venue'
+    Communication:
+      description: Communication
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Communication'
+    Communications:
+      description: Communication[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Communication'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -38,6 +38,8 @@ tags:
     description: The venues of the event
   - name: Communications
     description: The event's communications and announcements.
+  - name: Organizations
+    description: The organizations of the event
 
 paths:
   /status:
@@ -675,6 +677,89 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /organizations:
+    get:
+      summary: Get the organizations
+      tags: [Organizations]
+      security:
+        - AuthFunction: []
+      responses:
+        200:
+          $ref: '#/components/responses/Organizations'
+    post:
+      summary: Insert a new organization
+      description: Requires to be content manager
+      tags: [Organizations]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        description: Organization
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Organization'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /organizations/{organizationId}:
+    get:
+      summary: Get an organization
+      tags: [Organizations]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: organizationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/Organization'
+    put:
+      summary: Edit an organization
+      description: Requires to be content manager
+      tags: [Organizations]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: organizationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: Organization
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        200:
+          $ref: '#/components/responses/Organization'
+        400:
+          $ref: '#/components/responses/BadParameters'
+    delete:
+      summary: Delete an organization
+      description: Requires to be content manager
+      tags: [Organizations]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: organizationId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:
@@ -794,6 +879,22 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/Communication'
+    Organization:
+      description: Organization
+      content:
+        application/json:
+          schema:
+            type: object
+            items:
+              $ref: '#/components/schemas/Organization'
+    Organizations:
+      description: Organization[]
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Organization'
     BadParameters:
       description: Bad input parameters
       content:

--- a/back-end/swagger.yaml
+++ b/back-end/swagger.yaml
@@ -1102,6 +1102,51 @@ paths:
           $ref: '#/components/responses/OperationCompleted'
         400:
           $ref: '#/components/responses/BadParameters'
+  /connections:
+    get:
+      summary: Get the connections of a user
+      tags: [Users]
+      security:
+        - AuthFunction: []
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+    post:
+      summary: Create a new connection between the requester user and a target user or confirm a pending connection
+      tags: [Users]
+      security:
+        - AuthFunction: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                userId:
+                  type: string
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        400:
+          $ref: '#/components/responses/BadParameters'
+  /connections/{connectionId}:
+    delete:
+      summary: Delete the connection of a user with a target
+      tags: [Users]
+      security:
+        - AuthFunction: []
+      parameters:
+        - name: connectionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          $ref: '#/components/responses/OperationCompleted'
+        400:
+          $ref: '#/components/responses/BadParameters'
 
 components:
   schemas:

--- a/front-end/src/app/tabs/communications/communications.service.ts
+++ b/front-end/src/app/tabs/communications/communications.service.ts
@@ -1,0 +1,103 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Communication } from '@models/communication.model';
+
+@Injectable({ providedIn: 'root' })
+export class CommunicationsService {
+  private communications: Communication[];
+
+  /**
+   * The number of communications to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.communications = (await this.api.getResource(['communications'])).map(c => new Communication(c));
+  }
+
+  /**
+   * Get (and optionally filter) the list of communications.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Communication[]> {
+    if (!this.communications || options.force) await this.loadList();
+    if (!this.communications) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.communications.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm =>
+            [x.communicationId, x.title].filter(f => f).some(f => f.toLowerCase().includes(searchTerm))
+          )
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage =
+          filteredList.findIndex(x => x.communicationId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a communication by its id.
+   */
+  async getById(communicationId: string): Promise<Communication> {
+    return new Communication(await this.api.getResource(['communications', communicationId]));
+  }
+
+  /**
+   * Insert a new communication.
+   */
+  async insert(communication: Communication): Promise<Communication> {
+    return new Communication(await this.api.postResource(['communications'], { body: communication }));
+  }
+  /**
+   * Update an existing communication.
+   */
+  async update(communication: Communication): Promise<Communication> {
+    return new Communication(
+      await this.api.putResource(['communications', communication.communicationId], {
+        body: communication
+      })
+    );
+  }
+  /**
+   * Delete a venue.
+   */
+  async delete(communication: Communication): Promise<void> {
+    await this.api.deleteResource(['communications', communication.communicationId]);
+  }
+
+  /**
+   * Mark communication as read.
+   */
+  async markAsRead(communicationId: string): Promise<Communication> {
+    const body = { action: 'MARK_AS_READ' };
+    return new Communication(await this.api.patchResource(['communications', communicationId], { body }));
+  }
+  /**
+   * Mark communication as unread.
+   */
+  async markAsUnread(communicationId: string): Promise<Communication> {
+    const body = { action: 'MARK_AS_UNREAD' };
+    return new Communication(await this.api.patchResource(['communications', communicationId], { body }));
+  }
+}

--- a/front-end/src/app/tabs/connections.service.ts
+++ b/front-end/src/app/tabs/connections.service.ts
@@ -1,0 +1,61 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Connection } from '@models/connection.model';
+
+@Injectable({ providedIn: 'root' })
+export class ConnectionsService {
+  private connections: Connection[];
+
+  /**
+   * The number of connections to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.connections = (await this.api.getResource(['connections'])).map(c => new Connection(c));
+  }
+
+  /**
+   * Get (and optionally filter) the list of connections.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    pending?: boolean;
+    startPaginationAfterId?: string;
+  }): Promise<Connection[]> {
+    if (!this.connections || options.force) await this.loadList();
+    if (!this.connections) return null;
+
+    let filteredList = this.connections.slice();
+
+    filteredList = filteredList.filter(c => (options.pending ? c.isPending : !c.isPending));
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage = filteredList.findIndex(x => x.connectionId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Insert a new connection.
+   */
+  async insert(userId: string): Promise<Connection> {
+    return new Connection(await this.api.postResource(['connections'], { body: { userId } }));
+  }
+  /**
+   * Delete a connection.
+   */
+  async delete(connection: Connection): Promise<void> {
+    await this.api.deleteResource(['connections', connection.connectionId]);
+  }
+}

--- a/front-end/src/app/tabs/organizations/organizations.service.ts
+++ b/front-end/src/app/tabs/organizations/organizations.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Organization } from '@models/organization.model';
+
+@Injectable({ providedIn: 'root' })
+export class OrganizationsService {
+  private organizations: Organization[];
+
+  /**
+   * The number of organizations to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.organizations = (await this.api.getResource(['organizations'])).map(o => new Organization(o));
+  }
+
+  /**
+   * Get (and optionally filter) the list of organizations.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Organization[]> {
+    if (!this.organizations || options.force) await this.loadList();
+    if (!this.organizations) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.organizations.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm =>
+            [x.organizationId, x.name].filter(f => f).some(f => f.toLowerCase().includes(searchTerm))
+          )
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage =
+          filteredList.findIndex(x => x.organizationId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a organization by its id.
+   */
+  async getById(organizationId: string): Promise<Organization> {
+    return new Organization(await this.api.getResource(['organizations', organizationId]));
+  }
+
+  /**
+   * Insert a new organization.
+   */
+  async insert(organization: Organization): Promise<Organization> {
+    return new Organization(await this.api.postResource(['organizations'], { body: organization }));
+  }
+  /**
+   * Update an existing organization.
+   */
+  async update(organization: Organization): Promise<Organization> {
+    return new Organization(
+      await this.api.putResource(['communications', organization.organizationId], {
+        body: organization
+      })
+    );
+  }
+  /**
+   * Delete an organization.
+   */
+  async delete(organization: Organization): Promise<void> {
+    await this.api.deleteResource(['organizations', organization.organizationId]);
+  }
+}

--- a/front-end/src/app/tabs/rooms/rooms.service.ts
+++ b/front-end/src/app/tabs/rooms/rooms.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Room } from '@models/room.model';
+
+@Injectable({ providedIn: 'root' })
+export class RoomsService {
+  private rooms: Room[];
+
+  /**
+   * The number of rooms to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.rooms = (await this.api.getResource(['rooms'])).map(r => new Room(r));
+  }
+
+  /**
+   * Get (and optionally filter) the list of rooms.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Room[]> {
+    if (!this.rooms || options.force) await this.loadList();
+    if (!this.rooms) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.rooms.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm =>
+            [x.roomId, x.name, x.venue?.venueId, x.venue?.name]
+              .filter(f => f)
+              .some(f => f.toLowerCase().includes(searchTerm))
+          )
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage = filteredList.findIndex(x => x.roomId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a room by its id.
+   */
+  async getById(roomId: string): Promise<Room> {
+    return new Room(await this.api.getResource(['rooms', roomId]));
+  }
+
+  /**
+   * Insert a new room.
+   */
+  async insert(room: Room): Promise<Room> {
+    return new Room(await this.api.postResource(['rooms'], { body: room }));
+  }
+  /**
+   * Update an existing room.
+   */
+  async update(room: Room): Promise<Room> {
+    return new Room(
+      await this.api.putResource(['rooms', room.roomId], {
+        body: room
+      })
+    );
+  }
+  /**
+   * Delete a room.
+   */
+  async delete(room: Room): Promise<void> {
+    await this.api.deleteResource(['rooms', room.roomId]);
+  }
+}

--- a/front-end/src/app/tabs/sessionRegistrations/sessionRegistrations.service.ts
+++ b/front-end/src/app/tabs/sessionRegistrations/sessionRegistrations.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { SessionRegistration } from '@models/sessionRegistration.model';
+
+@Injectable({ providedIn: 'root' })
+export class SessionRegistrationsService {
+  constructor(private api: IDEAApiService) {}
+
+  /**
+   * Get the list of registrations for the user or session.
+   */
+  async getList(sessionId?: string): Promise<SessionRegistration[]> {
+    return (await this.api.getResource(['registrations'], { params: { sessionId } })).map(
+      sr => new SessionRegistration(sr)
+    );
+  }
+
+  /**
+   * Get the full details of a registration by its id.
+   */
+  async getById(sessionId: string): Promise<SessionRegistration> {
+    return new SessionRegistration(await this.api.getResource(['registrations', sessionId]));
+  }
+
+  /**
+   * Insert a new registration.
+   */
+  async insert(sessionId: string): Promise<SessionRegistration> {
+    return new SessionRegistration(await this.api.postResource(['registrations', sessionId]));
+  }
+  /**
+   * Delete a registration.
+   */
+  async delete(registration: SessionRegistration): Promise<void> {
+    await this.api.deleteResource(['registrations', registration.sessionId]);
+  }
+}

--- a/front-end/src/app/tabs/sessions/sessions.service.ts
+++ b/front-end/src/app/tabs/sessions/sessions.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Session } from '@models/session.model';
+
+@Injectable({ providedIn: 'root' })
+export class SessionsService {
+  private sessions: Session[];
+
+  /**
+   * The number of sessions to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.sessions = (await this.api.getResource(['sessions'])).map(s => new Session(s));
+  }
+
+  /**
+   * Get (and optionally filter) the list of sessions.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Session[]> {
+    if (!this.sessions || options.force) await this.loadList();
+    if (!this.sessions) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.sessions.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm =>
+            [x.sessionId, x.code, x.name].filter(f => f).some(f => f.toLowerCase().includes(searchTerm))
+          )
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage = filteredList.findIndex(x => x.sessionId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a session by its id.
+   */
+  async getById(sessionId: string): Promise<Session> {
+    return new Session(await this.api.getResource(['sessions', sessionId]));
+  }
+
+  /**
+   * Insert a new sesion.
+   */
+  async insert(session: Session): Promise<Session> {
+    return new Session(await this.api.postResource(['sessions'], { body: session }));
+  }
+  /**
+   * Update an existing session.
+   */
+  async update(session: Session): Promise<Session> {
+    return new Session(
+      await this.api.putResource(['sessions', session.sessionId], {
+        body: session
+      })
+    );
+  }
+  /**
+   * Delete a session.
+   */
+  async delete(session: Session): Promise<void> {
+    await this.api.deleteResource(['sessions', session.sessionId]);
+  }
+}

--- a/front-end/src/app/tabs/speakers/speakers.service.ts
+++ b/front-end/src/app/tabs/speakers/speakers.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Speaker } from '@models/speaker.model';
+
+@Injectable({ providedIn: 'root' })
+export class SpeakersService {
+  private speakers: Speaker[];
+
+  /**
+   * The number of speakers to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.speakers = (await this.api.getResource(['speakers'])).map(s => new Speaker(s));
+  }
+
+  /**
+   * Get (and optionally filter) the list of speakers.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Speaker[]> {
+    if (!this.speakers || options.force) await this.loadList();
+    if (!this.speakers) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.speakers.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm =>
+            [x.speakerId, x.name, x.contactEmail, x.organization?.organizationId, x.organization?.name]
+              .filter(f => f)
+              .some(f => f.toLowerCase().includes(searchTerm))
+          )
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage = filteredList.findIndex(x => x.speakerId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a speaker by its id.
+   */
+  async getById(speakerId: string): Promise<Speaker> {
+    return new Speaker(await this.api.getResource(['speakers', speakerId]));
+  }
+
+  /**
+   * Insert a new speaker.
+   */
+  async insert(speaker: Speaker): Promise<Speaker> {
+    return new Speaker(await this.api.postResource(['speakers'], { body: speaker }));
+  }
+  /**
+   * Update an existing speaker.
+   */
+  async update(speaker: Speaker): Promise<Speaker> {
+    return new Speaker(
+      await this.api.putResource(['speakers', speaker.speakerId], {
+        body: speaker
+      })
+    );
+  }
+  /**
+   * Delete a speaker.
+   */
+  async delete(speaker: Speaker): Promise<void> {
+    await this.api.deleteResource(['speakers', speaker.speakerId]);
+  }
+}

--- a/front-end/src/app/tabs/user/user.service.ts
+++ b/front-end/src/app/tabs/user/user.service.ts
@@ -77,4 +77,26 @@ export class UserService {
     const { url } = await this.api.patchResource(['users', 'me'], { body });
     return url;
   }
+
+  /**
+   * Favorite a session.
+   */
+  async addFavoriteSession(sessionId: string): Promise<void> {
+    const body = { action: 'ADD_FAVORITE_SESSION', sessionId };
+    await this.api.patchResource(['users'], { body });
+  }
+  /**
+   * Remove a session from the favorites.
+   */
+  async removeFavoriteSession(sessionId: string): Promise<void> {
+    const body = { action: 'REMOVE_FAVORITE_SESSION', sessionId };
+    await this.api.patchResource(['users'], { body });
+  }
+  /**
+   * Get the user's favorited sessions (IDs).
+   */
+  async getFavoriteSessions(): Promise<string[]> {
+    const body = { action: 'GET_FAVORITE_SESSIONS' };
+    return await this.api.patchResource(['users'], { body });
+  }
 }

--- a/front-end/src/app/tabs/venues/venues.service.ts
+++ b/front-end/src/app/tabs/venues/venues.service.ts
@@ -1,0 +1,85 @@
+import { Injectable } from '@angular/core';
+import { IDEAApiService } from '@idea-ionic/common';
+
+import { Venue } from '@models/venue.model';
+
+@Injectable({ providedIn: 'root' })
+export class VenuesService {
+  private venues: Venue[];
+
+  /**
+   * The number of venues to consider for the pagination, when active.
+   */
+  MAX_PAGE_SIZE = 24;
+
+  constructor(private api: IDEAApiService) {}
+
+  private async loadList(): Promise<void> {
+    this.venues = (await this.api.getResource(['venues'])).map(v => new Venue(v));
+  }
+
+  /**
+   * Get (and optionally filter) the list of venues.
+   * Note: it can be paginated.
+   * Note: it's a slice of the array.
+   */
+  async getList(options: {
+    force?: boolean;
+    withPagination?: boolean;
+    startPaginationAfterId?: string;
+    search?: string;
+  }): Promise<Venue[]> {
+    if (!this.venues || options.force) await this.loadList();
+    if (!this.venues) return null;
+
+    options.search = options.search ? String(options.search).toLowerCase() : '';
+
+    let filteredList = this.venues.slice();
+
+    if (options.search)
+      filteredList = filteredList.filter(x =>
+        options.search
+          .split(' ')
+          .every(searchTerm => [x.venueId, x.name].filter(f => f).some(f => f.toLowerCase().includes(searchTerm)))
+      );
+
+    if (options.withPagination && filteredList.length > this.MAX_PAGE_SIZE) {
+      let indexOfLastOfPreviousPage = 0;
+      if (options.startPaginationAfterId)
+        indexOfLastOfPreviousPage = filteredList.findIndex(x => x.venueId === options.startPaginationAfterId) || 0;
+      filteredList = filteredList.slice(0, indexOfLastOfPreviousPage + this.MAX_PAGE_SIZE);
+    }
+
+    return filteredList;
+  }
+
+  /**
+   * Get the full details of a venue by its id.
+   */
+  async getById(venueId: string): Promise<Venue> {
+    return new Venue(await this.api.getResource(['venues', venueId]));
+  }
+
+  /**
+   * Insert a new venue.
+   */
+  async insert(venue: Venue): Promise<Venue> {
+    return new Venue(await this.api.postResource(['venues'], { body: venue }));
+  }
+  /**
+   * Update an existing venue.
+   */
+  async update(venue: Venue): Promise<Venue> {
+    return new Venue(
+      await this.api.putResource(['venues', venue.venueId], {
+        body: venue
+      })
+    );
+  }
+  /**
+   * Delete a venue.
+   */
+  async delete(venue: Venue): Promise<void> {
+    await this.api.deleteResource(['venues', venue.venueId]);
+  }
+}


### PR DESCRIPTION
relates to #78 

# WARNING: Changes to the data from previous version!

## Sessions

Speakers are no longer an attribute of the model (i.e. `speaker1`, `speaker2`, etc...) but an array of speakers, allowing us to have more speakers. However the Front-End will have to be adapted to this new structure.

## Session Registrations

We might possibly need to add more user information to this model (such as a `name` or a profile picture) to display the reigstered users in a session on the Front-End.
The logic to check wether the session registration is open is no longer inside the model but will be added (by me) to the configurations model.

## Users

We removed the CV data and actions as well as the social media links - at least for now. We might add LinkedIn in the future.
Map information such as address, latitute and longitude have been removed from the user model and will be added when the map feature is readded to this app version

## Speakers

Check wether it is possible to update the Speaker crreation UI in the front-end to pass data from an exising user (like name and profile picture) to speed up the creation of the speakers and potentially linking speakers and users to their sessions

## Connection

We removed the Summary and Profile classes from the user model as there is no longer as much sensitive information that we need to hide from the public. However in the future we might add new sensitive data that we should only display to connected users so I'll leave this here.


Tomorrow or the day after I'll create the individual issues for each front-end section.
