### PR TITLE
109 agenda session registrations

### DIFF
--- a/back-end/src/handlers/registrations.ts
+++ b/back-end/src/handlers/registrations.ts
@@ -193,8 +193,14 @@ class SessionRegistrations extends ResourceController {
       const sessionStartDate = s.calcDatetimeWithoutTimezone(s.startsAt);
       const sessionEndDate = s.calcDatetimeWithoutTimezone(s.endsAt);
 
-      const targetSessionStart = session.calcDatetimeWithoutTimezone(session.startsAt);
-      const targetSessionEnd = session.calcDatetimeWithoutTimezone(session.endsAt);
+      const targetSessionStart = session.calcDatetimeWithoutTimezone(
+        session.startsAt,
+        -1 * this.configurations.sessionRegistrationBuffer || 0
+      );
+      const targetSessionEnd = session.calcDatetimeWithoutTimezone(
+        session.endsAt,
+        this.configurations.sessionRegistrationBuffer || 0
+      );
 
       // it's easier to prove a session is valid than it is to prove it's invalid. (1 vs 5 conditional checks)
       return sessionStartDate >= targetSessionEnd || sessionEndDate <= targetSessionStart;

--- a/back-end/src/handlers/sessions.ts
+++ b/back-end/src/handlers/sessions.ts
@@ -73,13 +73,13 @@ class Sessions extends ResourceController {
       await ddb.get({ TableName: DDB_TABLES.rooms, Key: { roomId: this.session.room.roomId } })
     );
 
-    const getRooms = await ddb.batchGet(
+    const getSpeakers = await ddb.batchGet(
       DDB_TABLES.speakers,
       this.session.speakers?.map(s => ({ speakerId: s.speakerId })),
       true
     )
 
-    this.session.speakers = getRooms.map(s => new SpeakerLinked(s));
+    this.session.speakers = getSpeakers.map(s => new SpeakerLinked(s));
 
     const errors = this.session.validate();
     if (errors.length) throw new HandledError(`Invalid fields: ${errors.join(', ')}`);

--- a/back-end/src/handlers/sessions.ts
+++ b/back-end/src/handlers/sessions.ts
@@ -69,20 +69,20 @@ class Sessions extends ResourceController {
     return await this.putSafeResource();
   }
   private async putSafeResource(opts: { noOverwrite?: boolean } = {}): Promise<Session> {
-    const errors = this.session.validate();
-    if (errors.length) throw new HandledError(`Invalid fields: ${errors.join(', ')}`);
-
     this.session.room = new RoomLinked(
       await ddb.get({ TableName: DDB_TABLES.rooms, Key: { roomId: this.session.room.roomId } })
     );
 
-    this.session.speakers = (
-      await ddb.batchGet(
-        DDB_TABLES.speakers,
-        this.session.speakers?.map(speakerId => ({ speakerId })),
-        true
-      )
-    ).map(s => new SpeakerLinked(s));
+    const getRooms = await ddb.batchGet(
+      DDB_TABLES.speakers,
+      this.session.speakers?.map(s => ({ speakerId: s.speakerId })),
+      true
+    )
+
+    this.session.speakers = getRooms.map(s => new SpeakerLinked(s));
+
+    const errors = this.session.validate();
+    if (errors.length) throw new HandledError(`Invalid fields: ${errors.join(', ')}`);
 
     try {
       const putParams: any = { TableName: DDB_TABLES.sessions, Item: this.session };

--- a/back-end/src/models/configurations.model.ts
+++ b/back-end/src/models/configurations.model.ts
@@ -5,8 +5,7 @@ import { User } from '../models/user.model';
 import { ServiceLanguages } from './serviceLanguages.enum';
 
 export const LANGUAGES = new Languages({ default: ServiceLanguages.English, available: [ServiceLanguages.English] });
-
-const DEFAULT_SESSION_REGISTRATION_BUFFER = 10;
+const DEFAULT_SESSION_REGISTRATION_BUFFER_MINUTES = 10;
 
 export class Configurations extends Resource {
   static PK = 'EGM';
@@ -69,7 +68,7 @@ export class Configurations extends Resource {
     this.sessionRegistrationBuffer = this.clean(
       x.sessionRegistrationBuffer,
       Number,
-      DEFAULT_SESSION_REGISTRATION_BUFFER
+      DEFAULT_SESSION_REGISTRATION_BUFFER_MINUTES
     );
     this.canCountryLeadersAssignSpots = this.clean(x.canCountryLeadersAssignSpots, Boolean);
     this.registrationFormDef = new CustomBlockMeta(x.registrationFormDef, LANGUAGES);

--- a/back-end/src/models/configurations.model.ts
+++ b/back-end/src/models/configurations.model.ts
@@ -6,6 +6,8 @@ import { ServiceLanguages } from './serviceLanguages.enum';
 
 export const LANGUAGES = new Languages({ default: ServiceLanguages.English, available: [ServiceLanguages.English] });
 
+const DEFAULT_SESSION_REGISTRATION_BUFFER = 10;
+
 export class Configurations extends Resource {
   static PK = 'EGM';
 
@@ -25,6 +27,10 @@ export class Configurations extends Resource {
    * Whether participants can register for sessions.
    */
   areSessionRegistrationsOpen: boolean;
+  /**
+   * The minimum amount of time (in minutes) a user must leave open between sessions.
+   */
+  sessionRegistrationBuffer: number;
   /**
    * Whether the delegation leaders can assign spots.
    */
@@ -60,6 +66,11 @@ export class Configurations extends Resource {
     this.isRegistrationOpenForESNers = this.clean(x.isRegistrationOpenForESNers, Boolean);
     this.isRegistrationOpenForExternals = this.clean(x.isRegistrationOpenForExternals, Boolean);
     this.areSessionRegistrationsOpen = this.clean(x.areSessionRegistrationsOpen, Boolean);
+    this.sessionRegistrationBuffer = this.clean(
+      x.sessionRegistrationBuffer,
+      Number,
+      DEFAULT_SESSION_REGISTRATION_BUFFER
+    );
     this.canCountryLeadersAssignSpots = this.clean(x.canCountryLeadersAssignSpots, Boolean);
     this.registrationFormDef = new CustomBlockMeta(x.registrationFormDef, LANGUAGES);
     this.currency = this.clean(x.currency, String);
@@ -81,6 +92,7 @@ export class Configurations extends Resource {
   validate(): string[] {
     const e = super.validate();
     this.registrationFormDef.validate(LANGUAGES).forEach(ea => e.push(`registrationFormDef.${ea}`));
+    if (this.sessionRegistrationBuffer < 0) e.push('sessionRegistrationBuffer')
     return e;
   }
 

--- a/back-end/src/models/configurations.model.ts
+++ b/back-end/src/models/configurations.model.ts
@@ -22,6 +22,10 @@ export class Configurations extends Resource {
    */
   isRegistrationOpenForExternals: boolean;
   /**
+   * Whether participants can register for sessions.
+   */
+  areSessionRegistrationsOpen: boolean;
+  /**
    * Whether the delegation leaders can assign spots.
    */
   canCountryLeadersAssignSpots: boolean;
@@ -55,6 +59,7 @@ export class Configurations extends Resource {
     this.PK = Configurations.PK;
     this.isRegistrationOpenForESNers = this.clean(x.isRegistrationOpenForESNers, Boolean);
     this.isRegistrationOpenForExternals = this.clean(x.isRegistrationOpenForExternals, Boolean);
+    this.areSessionRegistrationsOpen = this.clean(x.areSessionRegistrationsOpen, Boolean);
     this.canCountryLeadersAssignSpots = this.clean(x.canCountryLeadersAssignSpots, Boolean);
     this.registrationFormDef = new CustomBlockMeta(x.registrationFormDef, LANGUAGES);
     this.currency = this.clean(x.currency, String);

--- a/back-end/src/models/organization.model.ts
+++ b/back-end/src/models/organization.model.ts
@@ -25,10 +25,6 @@ export class Organization extends Resource {
    * The organization's contact email.
    */
   contactEmail: string;
-  /**
-   * A link to perform a contact action.
-   */
-  contactAction: string; // @todo check this
 
   load(x: any): void {
     super.load(x);
@@ -38,7 +34,6 @@ export class Organization extends Resource {
     this.description = this.clean(x.description, String);
     this.website = this.clean(x.website, String);
     this.contactEmail = this.clean(x.contactEmail, String);
-    this.contactAction = this.clean(x.contactAction, String);
   }
   safeLoad(newData: any, safeData: any): void {
     super.safeLoad(newData, safeData);
@@ -47,13 +42,10 @@ export class Organization extends Resource {
   validate(): string[] {
     const e = super.validate();
     if (isEmpty(this.name)) e.push('name');
-    if (this.website && isEmpty(this.website, 'url')) e.push('website');
-    if (this.contactEmail && isEmpty(this.contactEmail, 'email')) e.push('contactEmail');
     return e;
   }
 }
 
-// @todo check this
 export class OrganizationLinked extends Resource {
   organizationId: string;
   name: string;

--- a/back-end/src/models/room.model.ts
+++ b/back-end/src/models/room.model.ts
@@ -27,10 +27,6 @@ export class Room extends Resource {
    * An URI for an image of the room.
    */
   imageURI: string;
-  /**
-   * An URI for a plan of the room.
-   */
-  planImageURI: string;
 
   load(x: any): void {
     super.load(x);
@@ -40,7 +36,6 @@ export class Room extends Resource {
     this.internalLocation = this.clean(x.internalLocation, String);
     this.description = this.clean(x.description, String);
     this.imageURI = this.clean(x.imageURI, String);
-    this.planImageURI = this.clean(x.planImageURI, String);
   }
   safeLoad(newData: any, safeData: any): void {
     super.safeLoad(newData, safeData);

--- a/back-end/src/models/session.model.ts
+++ b/back-end/src/models/session.model.ts
@@ -94,6 +94,7 @@ export class Session extends Resource {
     if (isEmpty(this.durationMinutes)) e.push('durationMinutes');
     if (!this.room.roomId) e.push('room');
     if (!this.speakers?.length) e.push('speakers');
+    if (this.requiresRegistration && !this.limitOfParticipants) e.push('limitOfParticipants');
     return e;
   }
 
@@ -106,6 +107,10 @@ export class Session extends Resource {
 
   isFull(): boolean {
     return this.requiresRegistration ? this.numberOfParticipants >= this.limitOfParticipants : false
+  }
+
+  getSpeakers(): string {
+    return this.speakers.map(s => s.name).join(', ')
   }
 }
 

--- a/back-end/src/models/session.model.ts
+++ b/back-end/src/models/session.model.ts
@@ -4,7 +4,7 @@ import { RoomLinked } from './room.model';
 import { SpeakerLinked } from './speaker.model';
 
 /**
- * YYYY-MM-DDTHH:MM, without timezone. // @todo do we need this?
+ * YYYY-MM-DDTHH:MM, without timezone.
  */
 type datetime = string;
 
@@ -76,9 +76,11 @@ export class Session extends Resource {
     this.endsAt = this.calcDatetimeWithoutTimezone(endsAt);
     this.room = typeof x.room === 'string' ? new RoomLinked({ roomId: x.room }) : new RoomLinked(x.room);
     this.speakers = this.cleanArray(x.speakers, x => new SpeakerLinked(x));
-    this.numberOfParticipants = this.clean(x.numberOfParticipants, Number, 0);
-    this.limitOfParticipants = this.clean(x.limitOfParticipants, Number);
-    this.requiresRegistration = Object.keys(IndividualSessionType).includes(this.type);
+    this.requiresRegistration = this.type !== SessionType.COMMON;
+    if (this.requiresRegistration) {
+      this.numberOfParticipants = this.clean(x.numberOfParticipants, Number, 0);
+      this.limitOfParticipants = this.clean(x.limitOfParticipants, Number);
+    }
   }
   safeLoad(newData: any, safeData: any): void {
     super.safeLoad(newData, safeData);
@@ -103,47 +105,17 @@ export class Session extends Resource {
   }
 
   isFull(): boolean {
-    return this.numberOfParticipants >= this.limitOfParticipants;
+    return this.requiresRegistration ? this.numberOfParticipants >= this.limitOfParticipants : false
   }
 }
 
-// @todo don't have three enums...
-// @todo check if any is missing or we need to add.
-export enum CommonSessionType {
-  OPENING = 'OPENING',
-  KEYNOTE = 'KEYNOTE',
-  MORNING = 'MORNING',
-  POSTER = 'POSTER',
-  EXPO = 'EXPO',
-  CANDIDATES = 'CANDIDATES',
-  HARVESTING = 'HARVESTING',
-  CLOSING = 'CLOSING',
-  OTHER = 'OTHER'
-}
-
-export enum IndividualSessionType {
-  DISCUSSION = 'DISCUSSION',
-  TALK = 'TALK',
-  IGNITE = 'IGNITE',
-  CAMPFIRE = 'CAMPFIRE',
-  IDEAS = 'IDEAS',
-  INCUBATOR = 'INCUBATOR'
-}
 
 export enum SessionType {
-  OPENING = 'OPENING',
-  KEYNOTE = 'KEYNOTE',
-  MORNING = 'MORNING',
-  POSTER = 'POSTER',
-  EXPO = 'EXPO',
-  CANDIDATES = 'CANDIDATES',
-  HARVESTING = 'HARVESTING',
-  CLOSING = 'CLOSING',
   DISCUSSION = 'DISCUSSION',
   TALK = 'TALK',
   IGNITE = 'IGNITE',
   CAMPFIRE = 'CAMPFIRE',
-  IDEAS = 'IDEAS',
   INCUBATOR = 'INCUBATOR',
-  OTHER = 'OTHER'
+  HUB = 'HUB',
+  COMMON = 'COMMON'
 }

--- a/back-end/src/models/session.model.ts
+++ b/back-end/src/models/session.model.ts
@@ -100,9 +100,19 @@ export class Session extends Resource {
 
   // @todo add a method to check if a user/speaker is in the session or not
 
-  calcDatetimeWithoutTimezone(dateToFormat: Date | string | number): datetime {
+  calcDatetimeWithoutTimezone(dateToFormat: Date | string | number, bufferInMinutes = 0): datetime {
     const date = new Date(dateToFormat);
-    return new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+    return new Date(
+      date.getTime() -
+        this.convertMinutesToMilliseconds(date.getTimezoneOffset()) +
+        this.convertMinutesToMilliseconds(bufferInMinutes)
+    )
+      .toISOString()
+      .slice(0, 16);
+  }
+
+  convertMinutesToMilliseconds(minutes: number) {
+    return minutes * 60 * 1000;
   }
 
   isFull(): boolean {

--- a/back-end/src/models/sessionRegistration.model.ts
+++ b/back-end/src/models/sessionRegistration.model.ts
@@ -20,7 +20,7 @@ export class SessionRegistration extends Resource {
   /**
    * The user's ESN Country if any.
    */
-  esnCountry?: string;
+  sectionCountry?: string;
 
   load(x: any): void {
     super.load(x);
@@ -28,6 +28,6 @@ export class SessionRegistration extends Resource {
     this.userId = this.clean(x.userId, String);
     this.registrationDateInMs = this.clean(x.registrationDateInMs, t => new Date(t).getTime());
     this.name = this.clean(x.name, String);
-    this.esnCountry = this.clean(x.esnCountry, String);
+    if (x.sectionCountry) this.sectionCountry = this.clean(x.sectionCountry, String);
   }
 }

--- a/back-end/src/models/sessionRegistration.model.ts
+++ b/back-end/src/models/sessionRegistration.model.ts
@@ -13,11 +13,21 @@ export class SessionRegistration extends Resource {
    * The date of the registration.
    */
   registrationDateInMs: number;
+  /**
+   * The user's name.
+   */
+  name: string;
+  /**
+   * The user's ESN Country if any.
+   */
+  esnCountry?: string;
 
   load(x: any): void {
     super.load(x);
     this.sessionId = this.clean(x.sessionId, String);
     this.userId = this.clean(x.userId, String);
     this.registrationDateInMs = this.clean(x.registrationDateInMs, t => new Date(t).getTime());
+    this.name = this.clean(x.name, String);
+    this.esnCountry = this.clean(x.esnCountry, String);
   }
 }

--- a/back-end/src/models/speaker.model.ts
+++ b/back-end/src/models/speaker.model.ts
@@ -1,6 +1,7 @@
 import { isEmpty, Resource } from 'idea-toolbox';
 
 import { OrganizationLinked } from './organization.model';
+import { SocialMedia } from './user.model';
 
 export class Speaker extends Resource {
   /**
@@ -31,6 +32,10 @@ export class Speaker extends Resource {
    * The speaker's organization.
    */
   organization: OrganizationLinked;
+  /**
+   * The speaker's social media links, if any.
+   */
+  socialMedia: SocialMedia;
 
   static getRole(speaker: Speaker | SpeakerLinked): string {
     return speaker.organization.name || speaker.title
@@ -50,6 +55,10 @@ export class Speaker extends Resource {
       typeof x.organization === 'string'
         ? new OrganizationLinked({ organizationId: x.organization })
         : new OrganizationLinked(x.organization);
+    this.socialMedia = {}
+    if (x.socialMedia?.instagram) this.socialMedia.instagram = this.clean(x.socialMedia.instagram, String)
+    if (x.socialMedia?.linkedIn) this.socialMedia.linkedIn = this.clean(x.socialMedia.linkedIn, String)
+    if (x.socialMedia?.twitter) this.socialMedia.twitter = this.clean(x.socialMedia.twitter, String)
   }
   safeLoad(newData: any, safeData: any): void {
     super.safeLoad(newData, safeData);

--- a/back-end/src/models/speaker.model.ts
+++ b/back-end/src/models/speaker.model.ts
@@ -67,7 +67,6 @@ export class Speaker extends Resource {
   validate(): string[] {
     const e = super.validate();
     if (isEmpty(this.name)) e.push('name');
-    if (this.contactEmail && isEmpty(this.contactEmail, 'email')) e.push('contactEmail');
     if (!this.organization.organizationId) e.push('organization');
     return e;
   }

--- a/back-end/src/models/user.model.ts
+++ b/back-end/src/models/user.model.ts
@@ -72,6 +72,10 @@ export class User extends Resource {
    * The spot assigned for the event, if any.
    */
   spot?: EventSpotAttached;
+  /**
+   * The user's social media links, if any.
+   */
+  socialMedia: SocialMedia;
 
   load(x: any): void {
     super.load(x);
@@ -95,6 +99,10 @@ export class User extends Resource {
     this.registrationForm = x.registrationForm ?? {};
     if (x.registrationAt) this.registrationAt = this.clean(x.registrationAt, t => new Date(t).toISOString());
     if (x.spot) this.spot = new EventSpotAttached(x.spot);
+    this.socialMedia = {}
+    if (x.socialMedia?.instagram) this.socialMedia.instagram = this.clean(x.socialMedia.instagram, String)
+    if (x.socialMedia?.linkedIn) this.socialMedia.linkedIn = this.clean(x.socialMedia.linkedIn, String)
+    if (x.socialMedia?.twitter) this.socialMedia.twitter = this.clean(x.socialMedia.twitter, String)
   }
 
   safeLoad(newData: any, safeData: any): void {
@@ -236,4 +244,10 @@ export class UserFavoriteSession extends Resource {
     this.userId = this.clean(x.userId, String);
     this.sessionId = this.clean(x.sessionId, String);
   }
+}
+
+export interface SocialMedia {
+  instagram?: string;
+  linkedIn?: string;
+  twitter?: string;
 }

--- a/front-end/src/app/admin.guard.ts
+++ b/front-end/src/app/admin.guard.ts
@@ -1,0 +1,9 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+
+import { AppService } from './app.service';
+
+export const adminGuard: CanActivateFn = async (): Promise<boolean> => {
+  const _app = inject(AppService);
+  return _app.user.permissions.isAdmin;
+};

--- a/front-end/src/app/admin.guard.ts
+++ b/front-end/src/app/admin.guard.ts
@@ -1,9 +1,0 @@
-import { inject } from '@angular/core';
-import { CanActivateFn } from '@angular/router';
-
-import { AppService } from './app.service';
-
-export const adminGuard: CanActivateFn = async (): Promise<boolean> => {
-  const _app = inject(AppService);
-  return _app.user.permissions.isAdmin;
-};

--- a/front-end/src/app/app.service.ts
+++ b/front-end/src/app/app.service.ts
@@ -208,4 +208,13 @@ export class AppService {
     const p = this.user.permissions;
     return p.isAdmin || p.canManageRegistrations || p.canManageContents;
   }
+
+  formatDateShort = (date: string | Date): string => {
+    if (!(date instanceof Date)) date = new Date(date);
+    return date.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
+  };
+  formatTime(date: string | Date): string {
+    if (!(date instanceof Date)) date = new Date(date);
+    return new Date(date).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+  }
 }

--- a/front-end/src/app/common/htmlEditor.component.ts
+++ b/front-end/src/app/common/htmlEditor.component.ts
@@ -102,6 +102,8 @@ export class HTMLEditorComponent implements OnInit, OnChanges {
   }
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.editMode) this.sanitizedHtml = this._sanitizer.sanitize(SecurityContext.HTML, this.content);
+    if (changes.content) this.sanitizedHtml = this._sanitizer.sanitize(SecurityContext.HTML, this.content);
+
   }
 
   cleanHTMLCode(): void {

--- a/front-end/src/app/manage.guard.ts
+++ b/front-end/src/app/manage.guard.ts
@@ -5,5 +5,5 @@ import { AppService } from './app.service';
 
 export const manageGuard: CanActivateFn = async (): Promise<boolean> => {
   const _app = inject(AppService);
-  return _app.userCanManageSomething()
+  return _app.userCanManageSomething() || _app.user.permissions.isCountryLeader
 };

--- a/front-end/src/app/manage.guard.ts
+++ b/front-end/src/app/manage.guard.ts
@@ -5,9 +5,5 @@ import { AppService } from './app.service';
 
 export const manageGuard: CanActivateFn = async (): Promise<boolean> => {
   const _app = inject(AppService);
-  return (
-    _app.user.permissions.isAdmin ||
-    _app.user.permissions.canManageContents ||
-    _app.user.permissions.canManageRegistrations
-  );
+  return _app.userCanManageSomething()
 };

--- a/front-end/src/app/manage.guard.ts
+++ b/front-end/src/app/manage.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+
+import { AppService } from './app.service';
+
+export const manageGuard: CanActivateFn = async (): Promise<boolean> => {
+  const _app = inject(AppService);
+  return (
+    _app.user.permissions.isAdmin ||
+    _app.user.permissions.canManageContents ||
+    _app.user.permissions.canManageRegistrations
+  );
+};

--- a/front-end/src/app/spot.guard.ts
+++ b/front-end/src/app/spot.guard.ts
@@ -5,5 +5,6 @@ import { AppService } from './app.service';
 
 export const spotGuard: CanActivateFn = async (): Promise<boolean> => {
   const _app = inject(AppService);
-  return _app.user.spot?.paymentConfirmedAt ? true : false;
+  if (_app.userCanManageSomething()) return true
+  else return _app.user.spot?.paymentConfirmedAt ? true : false;
 };

--- a/front-end/src/app/spot.guard.ts
+++ b/front-end/src/app/spot.guard.ts
@@ -1,0 +1,9 @@
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+
+import { AppService } from './app.service';
+
+export const spotGuard: CanActivateFn = async (): Promise<boolean> => {
+  const _app = inject(AppService);
+  return _app.user.spot?.paymentConfirmedAt ? true : false;
+};

--- a/front-end/src/app/tabs/manage/configurations/registrations/registrationsConfig.page.html
+++ b/front-end/src/app/tabs/manage/configurations/registrations/registrationsConfig.page.html
@@ -42,6 +42,12 @@
         {{ 'MANAGE.ALLOW_SESSION_REGISTRATIONS' | translate }}
       </ion-checkbox>
     </ion-item>
+    <ion-item [class.fieldHasError]="hasFieldAnError('sessionRegistrationBuffer')">
+      <ion-label position="stacked">
+        {{ 'MANAGE.SESSION_BUFFER' | translate }}
+      </ion-label>
+      <ion-input [(ngModel)]="configurations.sessionRegistrationBuffer" [disabled]="!editMode"></ion-input>
+    </ion-item>
     <ion-item>
       <ion-checkbox [disabled]="!editMode" [(ngModel)]="configurations.canCountryLeadersAssignSpots">
         {{ 'MANAGE.ALLOW_COUNTRY_LEADER_ASSIGN_SPOT' | translate }}

--- a/front-end/src/app/tabs/manage/configurations/registrations/registrationsConfig.page.html
+++ b/front-end/src/app/tabs/manage/configurations/registrations/registrationsConfig.page.html
@@ -38,6 +38,11 @@
       </ion-checkbox>
     </ion-item>
     <ion-item>
+      <ion-checkbox [disabled]="!editMode" [(ngModel)]="configurations.areSessionRegistrationsOpen">
+        {{ 'MANAGE.ALLOW_SESSION_REGISTRATIONS' | translate }}
+      </ion-checkbox>
+    </ion-item>
+    <ion-item>
       <ion-checkbox [disabled]="!editMode" [(ngModel)]="configurations.canCountryLeadersAssignSpots">
         {{ 'MANAGE.ALLOW_COUNTRY_LEADER_ASSIGN_SPOT' | translate }}
       </ion-checkbox>

--- a/front-end/src/app/tabs/manage/manage.page.html
+++ b/front-end/src/app/tabs/manage/manage.page.html
@@ -40,21 +40,44 @@
           <p>{{ 'MANAGE.CONTENTS_I' | translate }}</p>
         </ion-label>
       </ion-list-header>
-      <ion-item>
-        <ion-icon slot="start" icon="volume-high-outline"></ion-icon>
-        <ion-label>{{ 'MANAGE.COMMUNICATIONS' | translate }}</ion-label>
+      <ion-item
+        button
+        detail
+        (click)="addVenue()"
+      >
+        <ion-icon slot="start" icon="home"></ion-icon>
+        <ion-label>{{ 'MANAGE.VENUES' | translate }}</ion-label>
       </ion-item>
-      <ion-item>
-        <ion-icon slot="start" icon="flame-outline"></ion-icon>
-        <ion-label>{{ 'MANAGE.SESSIONS' | translate }}</ion-label>
+      <ion-item
+        button
+        detail
+        (click)="addRoom()"
+      >
+        <ion-icon slot="start" icon="cube"></ion-icon>
+        <ion-label>{{ 'MANAGE.ROOMS' | translate }}</ion-label>
       </ion-item>
-      <ion-item>
+      <ion-item
+        button
+        detail
+        (click)="addOrganization()"
+      >
+        <ion-icon slot="start" icon="briefcase-outline"></ion-icon>
+        <ion-label>{{ 'MANAGE.ORGANIZATIONS' | translate }}</ion-label>
+      </ion-item>
+      <ion-item
+        button
+        detail
+        (click)="addSpeaker()"
+      >
         <ion-icon slot="start" icon="mic-outline"></ion-icon>
         <ion-label>{{ 'MANAGE.SPEAKERS' | translate }}</ion-label>
       </ion-item>
-      <ion-item>
-        <ion-icon slot="start" icon="briefcase-outline"></ion-icon>
-        <ion-label>{{ 'MANAGE.ORGANIZATIONS' | translate }}</ion-label>
+      <ion-item
+        button
+        detail
+      >
+        <ion-icon slot="start" icon="flame-outline"></ion-icon>
+        <ion-label>{{ 'MANAGE.SESSIONS' | translate }}</ion-label>
       </ion-item>
     </ng-container>
     <ng-container *ngIf="app.user.permissions.isAdmin">

--- a/front-end/src/app/tabs/manage/manage.page.html
+++ b/front-end/src/app/tabs/manage/manage.page.html
@@ -75,6 +75,7 @@
       <ion-item
         button
         detail
+        (click)="addSession()"
       >
         <ion-icon slot="start" icon="flame-outline"></ion-icon>
         <ion-label>{{ 'MANAGE.SESSIONS' | translate }}</ion-label>

--- a/front-end/src/app/tabs/manage/manage.page.ts
+++ b/front-end/src/app/tabs/manage/manage.page.ts
@@ -8,6 +8,7 @@ import { ManageOrganizationComponent } from '../organizations/manageOrganization
 import { ManageSpeakerComponent } from '../speakers/manageSpeaker.component';
 import { ManageVenueComponent } from '../venues/manageVenue.component';
 import { ManageRoomComponent } from '../rooms/manageRooms.component';
+import { ManageSessionComponent } from '../sessions/manageSession.component';
 
 import { AppService } from '@app/app.service';
 import { UsefulLinksService } from '@app/common/usefulLinks/usefulLinks.service';
@@ -18,6 +19,7 @@ import { Organization } from '@models/organization.model';
 import { Venue } from '@models/venue.model';
 import { Speaker } from '@models/speaker.model';
 import { Room } from '@models/room.model';
+import { Session } from '@models/session.model';
 
 @Component({
   selector: 'manage',
@@ -108,6 +110,14 @@ export class ManagePage {
     const modal = await this.modalCtrl.create({
       component: ManageRoomComponent,
       componentProps: { room: new Room() },
+      backdropDismiss: false
+    });
+    await modal.present();
+  }
+  async addSession(): Promise<void> {
+    const modal = await this.modalCtrl.create({
+      component: ManageSessionComponent,
+      componentProps: { session: new Session() },
       backdropDismiss: false
     });
     await modal.present();

--- a/front-end/src/app/tabs/manage/manage.page.ts
+++ b/front-end/src/app/tabs/manage/manage.page.ts
@@ -4,12 +4,20 @@ import { IDEALoadingService, IDEAMessageService } from '@idea-ionic/common';
 
 import { EmailTemplateComponent } from './configurations/emailTemplate/emailTemplate.component';
 import { ManageUsefulLinkStandaloneComponent } from '@app/common/usefulLinks/manageUsefulLink.component';
+import { ManageOrganizationComponent } from '../organizations/manageOrganization.component';
+import { ManageSpeakerComponent } from '../speakers/manageSpeaker.component';
+import { ManageVenueComponent } from '../venues/manageVenue.component';
+import { ManageRoomComponent } from '../rooms/manageRooms.component';
 
 import { AppService } from '@app/app.service';
 import { UsefulLinksService } from '@app/common/usefulLinks/usefulLinks.service';
 
 import { EmailTemplates, DocumentTemplates } from '@models/configurations.model';
 import { UsefulLink } from '@models/usefulLink.model';
+import { Organization } from '@models/organization.model';
+import { Venue } from '@models/venue.model';
+import { Speaker } from '@models/speaker.model';
+import { Room } from '@models/room.model';
 
 @Component({
   selector: 'manage',
@@ -70,5 +78,38 @@ export class ManagePage {
   }
   async addUsefulLink(): Promise<void> {
     await this.editUsefulLink(new UsefulLink());
+  }
+
+  async addOrganization(): Promise<void> {
+    const modal = await this.modalCtrl.create({
+      component: ManageOrganizationComponent,
+      componentProps: { organization: new Organization() },
+      backdropDismiss: false
+    });
+    await modal.present();
+  }
+  async addSpeaker(): Promise<void> {
+    const modal = await this.modalCtrl.create({
+      component: ManageSpeakerComponent,
+      componentProps: { speaker: new Speaker() },
+      backdropDismiss: false
+    });
+    await modal.present();
+  }
+  async addVenue(): Promise<void> {
+    const modal = await this.modalCtrl.create({
+      component: ManageVenueComponent,
+      componentProps: { venue: new Venue() },
+      backdropDismiss: false
+    });
+    await modal.present();
+  }
+  async addRoom(): Promise<void> {
+    const modal = await this.modalCtrl.create({
+      component: ManageRoomComponent,
+      componentProps: { room: new Room() },
+      backdropDismiss: false
+    });
+    await modal.present();
   }
 }

--- a/front-end/src/app/tabs/menu/menu.page.html
+++ b/front-end/src/app/tabs/menu/menu.page.html
@@ -14,7 +14,7 @@
       <ion-icon name="home" slot="start"></ion-icon>
       <ion-label>{{ 'MENU.HOME' | translate }}</ion-label>
     </ion-item>
-    <ion-item button color="white" (click)="app.goToInTabs(['sessions'])">
+    <ion-item button color="white" (click)="app.goToInTabs(['agenda'])">
       <ion-icon name="calendar" slot="start"></ion-icon>
       <ion-label>{{ 'MENU.AGENDA' | translate }}</ion-label>
     </ion-item>

--- a/front-end/src/app/tabs/organizations/manageOrganization.component.ts
+++ b/front-end/src/app/tabs/organizations/manageOrganization.component.ts
@@ -1,0 +1,187 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { AlertController, IonicModule, ModalController } from '@ionic/angular';
+import {
+  IDEALoadingService,
+  IDEAMessageService,
+  IDEATranslationsModule,
+  IDEATranslationsService
+} from '@idea-ionic/common';
+
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
+import { AppService } from '@app/app.service';
+import { MediaService } from 'src/app/common/media.service';
+
+import { Organization } from '@models/organization.model';
+import { OrganizationsService } from './organizations.service';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
+  selector: 'app-manage-organization',
+  template: `
+    <ion-header class="ion-no-border">
+      <ion-toolbar color="medium">
+        <ion-buttons slot="start">
+          <ion-button [title]="'COMMON.CANCEL' | translate" (click)="close()">
+            <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ 'ORGANIZATIONS.MANAGE_ORGANIZATION' | translate }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
+            <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content [class.ion-padding]="!app.isInMobileMode()">
+      <ion-list class="aList" lines="full">
+        <ion-item [class.fieldHasError]="hasFieldAnError('name')">
+          <ion-label position="stacked">
+            {{ 'ORGANIZATIONS.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input [(ngModel)]="organization.name"></ion-input>
+        </ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('imageURL')">
+          <ion-label position="stacked">{{ 'ORGANIZATIONS.IMAGE_URL' | translate }}</ion-label>
+          <ion-input [(ngModel)]="organization.imageURI"></ion-input>
+          <input type="file" accept="image/*" style="display: none" id="upload-image" (change)="uploadImage($event)" />
+          <ion-button
+          slot="end"
+          fill="clear"
+          color="medium"
+          class="ion-margin-top"
+          (click)="browseImagesForElementId('upload-image')"
+          >
+          <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
+        </ion-button>
+      </ion-item>
+      <ion-item>
+        <ion-label position="stacked">
+          {{ 'ORGANIZATIONS.WEBSITE' | translate }}
+        </ion-label>
+        <ion-input [(ngModel)]="organization.website"></ion-input>
+      </ion-item>
+      <ion-item>
+        <ion-label position="stacked">
+          {{ 'ORGANIZATIONS.EMAIL' | translate }}
+        </ion-label>
+        <ion-input [(ngModel)]="organization.contactEmail"></ion-input>
+      </ion-item>
+        <ion-list-header [class.fieldHasError]="hasFieldAnError('description')">
+          <ion-label>
+            <h2>{{ 'ORGANIZATION.DESCRIPTION' | translate }}</h2>
+          </ion-label>
+        </ion-list-header>
+        <app-html-editor [(content)]="organization.description" [editMode]="true"></app-html-editor>
+        <ion-row class="ion-padding-top" *ngIf="organization.organizationId">
+          <ion-col class="ion-text-right">
+            <ion-button color="danger" (click)="askAndDelete()">{{ 'COMMON.DELETE' | translate }}</ion-button>
+          </ion-col>
+        </ion-row>
+      </ion-list>
+    </ion-content>
+  `
+})
+export class ManageOrganizationComponent implements OnInit {
+  /**
+   * The organization to manage.
+   */
+  @Input() organization: Organization;
+
+  entityBeforeChange: Organization
+
+  errors = new Set<string>();
+
+  constructor(
+    private modalCtrl: ModalController,
+    private alertCtrl: AlertController,
+    private t: IDEATranslationsService,
+    private loading: IDEALoadingService,
+    private message: IDEAMessageService,
+    private _media: MediaService,
+    private _organizations: OrganizationsService,
+    public app: AppService
+  ) {}
+
+  ngOnInit() {
+    this.entityBeforeChange = new Organization(this.organization)
+  }
+
+  hasFieldAnError(field: string): boolean {
+    return this.errors.has(field);
+  }
+
+  browseImagesForElementId(elementId: string): void {
+    document.getElementById(elementId).click();
+  }
+  async uploadImage({ target }): Promise<void> {
+    const file = target.files[0];
+    if (!file) return;
+
+    try {
+      await this.loading.show();
+      const imageURI = await this._media.uploadImage(file);
+      await sleepForNumSeconds(3);
+      this.organization.imageURI = imageURI;
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      if (target) target.value = '';
+      this.loading.hide();
+    }
+  }
+
+  async save(): Promise<void> {
+    this.errors = new Set(this.organization.validate());
+    if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
+
+    try {
+      await this.loading.show();
+      let result: Organization;
+      if (!this.organization.organizationId) result = await this._organizations.insert(this.organization);
+      else result = await this._organizations.update(this.organization);
+      this.organization.load(result);
+      this.message.success('COMMON.OPERATION_COMPLETED');
+      this.close();
+    } catch (err) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+  close(): void {
+    this.organization = this.entityBeforeChange
+    this.modalCtrl.dismiss();
+  }
+
+  async askAndDelete(): Promise<void> {
+    const doDelete = async (): Promise<void> => {
+      try {
+        await this.loading.show();
+        await this._organizations.delete(this.organization);
+        this.message.success('COMMON.OPERATION_COMPLETED');
+        this.close();
+        this.app.goToInTabs(['organizations'])
+      } catch (error) {
+        this.message.error('COMMON.OPERATION_FAILED');
+      } finally {
+        this.loading.hide();
+      }
+    };
+    const header = this.t._('COMMON.ARE_YOU_SURE');
+    const message = this.t._('COMMON.ACTION_IS_IRREVERSIBLE');
+    const buttons = [
+      { text: this.t._('COMMON.CANCEL'), role: 'cancel' },
+      { text: this.t._('COMMON.DELETE'), role: 'destructive', handler: doDelete }
+    ];
+    const alert = await this.alertCtrl.create({ header, message, buttons });
+    alert.present();
+  }
+}
+
+const sleepForNumSeconds = (numSeconds = 1): Promise<void> =>
+  new Promise(resolve => setTimeout((): void => resolve(null), 1000 * numSeconds));

--- a/front-end/src/app/tabs/organizations/organization.page.html
+++ b/front-end/src/app/tabs/organizations/organization.page.html
@@ -1,6 +1,13 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>{{ 'ORGANIZATIONS.DETAILS' | translate }}</ion-title>
+    <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
+      <ng-container>
+        <ion-button color="ESNgreen" (click)="manageOrganization(organization)">
+          <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+        </ion-button>
+      </ng-container>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/front-end/src/app/tabs/organizations/organization.page.html
+++ b/front-end/src/app/tabs/organizations/organization.page.html
@@ -1,5 +1,10 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button color="primary" (click)="app.goToInTabs(['organizations'], { back: true })">
+        <ion-icon slot="icon-only" name="arrow-back" />
+      </ion-button>
+    </ion-buttons>
     <ion-title>{{ 'ORGANIZATIONS.DETAILS' | translate }}</ion-title>
     <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
       <ng-container>

--- a/front-end/src/app/tabs/organizations/organization.page.ts
+++ b/front-end/src/app/tabs/organizations/organization.page.ts
@@ -41,7 +41,7 @@ export class OrganizationPage implements OnInit {
       await this.loading.show();
       const organizationId = this.route.snapshot.paramMap.get('organizationId');
       this.organization = await this._organizations.getById(organizationId);
-      this.speakers = await this._speakers.getList({ organization: this.organization.organizationId, force: true });
+      this.speakers = await this._speakers.getOrganizationSpeakers(this.organization.organizationId);
     } catch (err) {
       this.message.error('COMMON.NOT_FOUND');
     } finally {
@@ -50,7 +50,7 @@ export class OrganizationPage implements OnInit {
   }
 
   async filterSpeakers(search: string = ''): Promise<void> {
-    this.speakers = await this._speakers.getList({ search, organization: this.organization.organizationId });
+    this.speakers = await this._speakers.getOrganizationSpeakers(this.organization.organizationId, search);
   }
 
   async manageOrganization(organization: Organization): Promise<void> {

--- a/front-end/src/app/tabs/organizations/organization.page.ts
+++ b/front-end/src/app/tabs/organizations/organization.page.ts
@@ -9,6 +9,8 @@ import { SpeakersService } from '../speakers/speakers.service';
 
 import { Speaker } from '@models/speaker.model';
 import { Organization } from '@models/organization.model';
+import { ModalController } from '@ionic/angular';
+import { ManageOrganizationComponent } from './manageOrganization.component';
 
 @Component({
   selector: 'app-organization',
@@ -21,6 +23,7 @@ export class OrganizationPage implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
+    private modalCtrl: ModalController,
     private loading: IDEALoadingService,
     private message: IDEAMessageService,
     private _organizations: OrganizationsService,
@@ -47,5 +50,19 @@ export class OrganizationPage implements OnInit {
 
   async filterSpeakers(search: string = ''): Promise<void> {
     this.speakers = await this._speakers.getList({ search, organization: this.organization.organizationId });
+  }
+
+  async manageOrganization(organization: Organization): Promise<void> {
+    if (!this.app.user.permissions.canManageContents) return
+
+    const modal = await this.modalCtrl.create({
+      component: ManageOrganizationComponent,
+      componentProps: { organization },
+      backdropDismiss: false
+    });
+    modal.onDidDismiss().then(async (): Promise<void> => {
+      this.organization = await this._organizations.getById(organization.organizationId);
+    });
+    await modal.present();
   }
 }

--- a/front-end/src/app/tabs/organizations/organization.page.ts
+++ b/front-end/src/app/tabs/organizations/organization.page.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { ModalController } from '@ionic/angular';
 
 import { IDEALoadingService, IDEAMessageService } from '@idea-ionic/common';
+
+import { ManageOrganizationComponent } from './manageOrganization.component';
 
 import { AppService } from 'src/app/app.service';
 import { OrganizationsService } from './organizations.service';
@@ -9,8 +12,6 @@ import { SpeakersService } from '../speakers/speakers.service';
 
 import { Speaker } from '@models/speaker.model';
 import { Organization } from '@models/organization.model';
-import { ModalController } from '@ionic/angular';
-import { ManageOrganizationComponent } from './manageOrganization.component';
 
 @Component({
   selector: 'app-organization',

--- a/front-end/src/app/tabs/organizations/organizationCard.component.ts
+++ b/front-end/src/app/tabs/organizations/organizationCard.component.ts
@@ -5,13 +5,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { IDEATranslationsModule } from '@idea-ionic/common';
 
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
 import { AppService } from 'src/app/app.service';
 
 import { Organization } from '@models/organization.model';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule],
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
   selector: 'app-organization-card',
   template: `
     <ion-card *ngIf="organization" color="white">
@@ -19,17 +21,14 @@ import { Organization } from '@models/organization.model';
       <ion-card-header>
         <ion-card-title>{{ organization.name }}</ion-card-title>
         <ion-card-subtitle>
-          <a [href]="(organization.website.startsWith('http') ? '' : 'http://') + organization.website" target="_blank">{{ organization.website }}</a>
+          <a *ngIf="organization.website" [href]="(organization.website.startsWith('http') ? '' : 'http://') + organization.website" target="_blank">{{ organization.website }}</a>
         </ion-card-subtitle>
         <ion-card-subtitle>
           <a [href]="'mailto:' + organization.contactEmail">{{ organization.contactEmail }}</a>
         </ion-card-subtitle>
       </ion-card-header>
       <ion-card-content>
-        <div class="divDescription" *ngIf="organization.description">
-          <ion-textarea readonly [rows]="4" [(ngModel)]="organization.description"></ion-textarea>
-        </div>
-
+      <app-html-editor [content]="organization.description" [editMode]="false"></app-html-editor>
       </ion-card-content>
     </ion-card>
 

--- a/front-end/src/app/tabs/organizations/organizations.service.ts
+++ b/front-end/src/app/tabs/organizations/organizations.service.ts
@@ -74,7 +74,7 @@ export class OrganizationsService {
    */
   async update(organization: Organization): Promise<Organization> {
     return new Organization(
-      await this.api.putResource(['communications', organization.organizationId], {
+      await this.api.putResource(['organizations', organization.organizationId], {
         body: organization
       })
     );

--- a/front-end/src/app/tabs/rooms/manageRooms.component.ts
+++ b/front-end/src/app/tabs/rooms/manageRooms.component.ts
@@ -66,7 +66,7 @@ import { VenueLinked } from '@models/venue.model';
             {{ 'ROOMS.VENUE' | translate }}
             <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
-          <ion-select interface="popover" [(ngModel)]="room.venue">
+          <ion-select interface="popover" [(ngModel)]="room.venue" [placeholder]="room?.venue?.name">
             <ion-select-option *ngFor="let venue of venues" [value]="venue">
               {{ venue.name }}
             </ion-select-option>

--- a/front-end/src/app/tabs/rooms/manageRooms.component.ts
+++ b/front-end/src/app/tabs/rooms/manageRooms.component.ts
@@ -61,8 +61,11 @@ import { VenueLinked } from '@models/venue.model';
             <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
           </ion-button>
         </ion-item>
-        <ion-item  [class.fieldHasError]="hasFieldAnError('venue')">
-          <ion-label position="stacked">{{ 'ROOMS.VENUE' | translate }}</ion-label>
+        <ion-item [class.fieldHasError]="hasFieldAnError('venue')">
+          <ion-label position="stacked">
+            {{ 'ROOMS.VENUE' | translate }}
+            <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
           <ion-select interface="popover" [(ngModel)]="room.venue">
             <ion-select-option *ngFor="let venue of venues" [value]="venue">
               {{ venue.name }}

--- a/front-end/src/app/tabs/rooms/manageRooms.component.ts
+++ b/front-end/src/app/tabs/rooms/manageRooms.component.ts
@@ -11,16 +11,18 @@ import {
 
 import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
 
+import { VenuesService } from '../venues/venues.service';
 import { AppService } from '@app/app.service';
 import { MediaService } from 'src/app/common/media.service';
-import { VenuesService } from './venues.service';
+import { RoomsService } from './rooms.service';
 
-import { Venue } from '@models/venue.model';
+import { Room } from '@models/room.model';
+import { VenueLinked } from '@models/venue.model';
 
 @Component({
   standalone: true,
   imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
-  selector: 'app-manage-venue',
+  selector: 'app-manage-room',
   template: `
     <ion-header class="ion-no-border">
       <ion-toolbar color="medium">
@@ -29,7 +31,7 @@ import { Venue } from '@models/venue.model';
             <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
           </ion-button>
         </ion-buttons>
-        <ion-title>{{ 'VENUES.MANAGE_VENUE' | translate }}</ion-title>
+        <ion-title>{{ 'ROOMS.MANAGE_ROOM' | translate }}</ion-title>
         <ion-buttons slot="end">
           <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
             <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>
@@ -41,13 +43,13 @@ import { Venue } from '@models/venue.model';
       <ion-list class="aList" lines="full">
         <ion-item [class.fieldHasError]="hasFieldAnError('name')">
           <ion-label position="stacked">
-            {{ 'VENUES.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
+            {{ 'ROOMS.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
-          <ion-input [(ngModel)]="venue.name"></ion-input>
+          <ion-input [(ngModel)]="room.name"></ion-input>
         </ion-item>
         <ion-item [class.fieldHasError]="hasFieldAnError('imageURL')">
-          <ion-label position="stacked">{{ 'VENUES.IMAGE_URL' | translate }}</ion-label>
-          <ion-input [(ngModel)]="venue.imageURI"></ion-input>
+          <ion-label position="stacked">{{ 'ROOMS.IMAGE_URL' | translate }}</ion-label>
+          <ion-input [(ngModel)]="room.imageURI"></ion-input>
           <input type="file" accept="image/*" style="display: none" id="upload-image" (change)="uploadImage($event)" />
           <ion-button
             slot="end"
@@ -59,31 +61,27 @@ import { Venue } from '@models/venue.model';
             <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
           </ion-button>
         </ion-item>
-        <ion-item>
-          <ion-label position="stacked">
-            {{ 'VENUES.ADDRESS' | translate }}
-          </ion-label>
-          <ion-input [(ngModel)]="venue.address"></ion-input>
+        <ion-item  [class.fieldHasError]="hasFieldAnError('venue')">
+          <ion-label position="stacked">{{ 'ROOMS.VENUE' | translate }}</ion-label>
+          <ion-select interface="popover" [(ngModel)]="room.venue">
+            <ion-select-option *ngFor="let venue of venues" [value]="venue">
+              {{ venue.name }}
+            </ion-select-option>
+          </ion-select>
         </ion-item>
         <ion-item>
           <ion-label position="stacked">
-            {{ 'VENUES.LATITUDE' | translate }}
+            {{ 'ROOMS.INTERNAL_LOCATION' | translate }}
           </ion-label>
-          <ion-input type="number" [(ngModel)]="venue.latitude"></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-label position="stacked">
-            {{ 'VENUES.LONGITUDE' | translate }}
-          </ion-label>
-          <ion-input type="number" [(ngModel)]="venue.longitude"></ion-input>
+          <ion-input [(ngModel)]="room.internalLocation"></ion-input>
         </ion-item>
         <ion-list-header [class.fieldHasError]="hasFieldAnError('description')">
           <ion-label>
-            <h2>{{ 'VENUES.DESCRIPTION' | translate }}</h2>
+            <h2>{{ 'ROOMS.DESCRIPTION' | translate }}</h2>
           </ion-label>
         </ion-list-header>
-        <app-html-editor [(content)]="venue.description" [editMode]="true"></app-html-editor>
-        <ion-row class="ion-padding-top" *ngIf="venue.venueId">
+        <app-html-editor [(content)]="room.description" [editMode]="true"></app-html-editor>
+        <ion-row class="ion-padding-top" *ngIf="room.roomId">
           <ion-col class="ion-text-right">
             <ion-button color="danger" (click)="askAndDelete()">{{ 'COMMON.DELETE' | translate }}</ion-button>
           </ion-col>
@@ -92,13 +90,14 @@ import { Venue } from '@models/venue.model';
     </ion-content>
   `
 })
-export class ManageVenueComponent implements OnInit {
+export class ManageRoomComponent implements OnInit {
   /**
-   * The venue to manage.
+   * The room to manage.
    */
-  @Input() venue: Venue;
+  @Input() room: Room;
 
-  entityBeforeChange: Venue;
+  entityBeforeChange: Room;
+  venues: VenueLinked[] = [];
 
   errors = new Set<string>();
 
@@ -110,11 +109,13 @@ export class ManageVenueComponent implements OnInit {
     private message: IDEAMessageService,
     private _media: MediaService,
     private _venues: VenuesService,
+    private _rooms: RoomsService,
     public app: AppService
   ) {}
 
   async ngOnInit() {
-    this.entityBeforeChange = new Venue(this.venue);
+    this.entityBeforeChange = new Room(this.room);
+    this.venues = (await this._venues.getList({ force: true })).map(v => new VenueLinked(v));
   }
 
   hasFieldAnError(field: string): boolean {
@@ -132,7 +133,7 @@ export class ManageVenueComponent implements OnInit {
       await this.loading.show();
       const imageURI = await this._media.uploadImage(file);
       await sleepForNumSeconds(3);
-      this.venue.imageURI = imageURI;
+      this.room.imageURI = imageURI;
     } catch (error) {
       this.message.error('COMMON.OPERATION_FAILED');
     } finally {
@@ -142,15 +143,15 @@ export class ManageVenueComponent implements OnInit {
   }
 
   async save(): Promise<void> {
-    this.errors = new Set(this.venue.validate());
+    this.errors = new Set(this.room.validate());
     if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
 
     try {
       await this.loading.show();
-      let result: Venue;
-      if (!this.venue.venueId) result = await this._venues.insert(this.venue);
-      else result = await this._venues.update(this.venue);
-      this.venue.load(result);
+      let result: Room;
+      if (!this.room.roomId) result = await this._rooms.insert(this.room);
+      else result = await this._rooms.update(this.room);
+      this.room.load(result);
       this.message.success('COMMON.OPERATION_COMPLETED');
       this.close();
     } catch (err) {
@@ -160,7 +161,7 @@ export class ManageVenueComponent implements OnInit {
     }
   }
   close(): void {
-    this.venue = this.entityBeforeChange;
+    this.room = this.entityBeforeChange;
     this.modalCtrl.dismiss();
   }
 
@@ -168,10 +169,10 @@ export class ManageVenueComponent implements OnInit {
     const doDelete = async (): Promise<void> => {
       try {
         await this.loading.show();
-        await this._venues.delete(this.venue);
+        await this._rooms.delete(this.room);
         this.message.success('COMMON.OPERATION_COMPLETED');
         this.close();
-        this.app.goToInTabs(['venues']);
+        this.app.goToInTabs(['venues', this.room.venue.venueId]);
       } catch (error) {
         this.message.error('COMMON.OPERATION_FAILED');
       } finally {

--- a/front-end/src/app/tabs/rooms/room.page.html
+++ b/front-end/src/app/tabs/rooms/room.page.html
@@ -1,6 +1,13 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>{{ 'ROOMS.DETAILS' | translate }}</ion-title>
+    <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
+      <ng-container>
+        <ion-button color="ESNgreen" (click)="manageRoom(room)">
+          <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+        </ion-button>
+      </ng-container>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/front-end/src/app/tabs/rooms/room.page.html
+++ b/front-end/src/app/tabs/rooms/room.page.html
@@ -1,5 +1,10 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button color="primary" (click)="app.goToInTabs(['venues', room.venue.venueId], { back: true })">
+        <ion-icon slot="icon-only" name="arrow-back" />
+      </ion-button>
+    </ion-buttons>
     <ion-title>{{ 'ROOMS.DETAILS' | translate }}</ion-title>
     <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
       <ng-container>

--- a/front-end/src/app/tabs/rooms/room.page.ts
+++ b/front-end/src/app/tabs/rooms/room.page.ts
@@ -37,7 +37,7 @@ export class RoomPage implements OnInit {
       await this.loading.show();
       const roomId = this.route.snapshot.paramMap.get('roomId');
       this.room = await this._rooms.getById(roomId);
-      this.sessions = await this._sessions.getList({ room: this.room.roomId, force: true });
+      this.sessions = await this._sessions.getSessionsInARoom(this.room.roomId);
     } catch (err) {
       this.message.error('COMMON.NOT_FOUND');
     } finally {
@@ -46,6 +46,6 @@ export class RoomPage implements OnInit {
   }
 
   async filterSessions(search: string = ''): Promise<void> {
-    this.sessions = await this._sessions.getList({ search, room: this.room.roomId });
+    this.sessions = await this._sessions.getSessionsInARoom(search, this.room.roomId)
   }
 }

--- a/front-end/src/app/tabs/rooms/room.page.ts
+++ b/front-end/src/app/tabs/rooms/room.page.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { ModalController } from '@ionic/angular';
 
 import { IDEALoadingService, IDEAMessageService } from '@idea-ionic/common';
+
+import { ManageRoomComponent } from './manageRooms.component';
 
 import { AppService } from 'src/app/app.service';
 import { RoomsService } from './rooms.service';
@@ -21,6 +24,7 @@ export class RoomPage implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
+    private modalCtrl: ModalController,
     private loading: IDEALoadingService,
     private message: IDEAMessageService,
     private _sessions: SessionsService,
@@ -47,5 +51,19 @@ export class RoomPage implements OnInit {
 
   async filterSessions(search: string = ''): Promise<void> {
     this.sessions = await this._sessions.getSessionsInARoom(search, this.room.roomId)
+  }
+
+  async manageRoom(room: Room): Promise<void> {
+    if (!this.app.user.permissions.canManageContents) return
+
+    const modal = await this.modalCtrl.create({
+      component: ManageRoomComponent,
+      componentProps: { room },
+      backdropDismiss: false
+    });
+    modal.onDidDismiss().then(async (): Promise<void> => {
+      this.room = await this._rooms.getById(room.roomId);
+    });
+    await modal.present();
   }
 }

--- a/front-end/src/app/tabs/rooms/roomCard.component.ts
+++ b/front-end/src/app/tabs/rooms/roomCard.component.ts
@@ -8,10 +8,11 @@ import { IDEATranslationsModule } from '@idea-ionic/common';
 import { AppService } from 'src/app/app.service';
 
 import { Room } from '@models/room.model';
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule],
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
   selector: 'app-room-card',
   template: `
     <ng-container *ngIf="room; else skeletonTemplate">
@@ -37,9 +38,7 @@ import { Room } from '@models/room.model';
           <ion-card-subtitle>{{ room.internalLocation }}</ion-card-subtitle>
         </ion-card-header>
         <ion-card-content>
-          <div class="divDescription" *ngIf="room.description">
-            <ion-textarea readonly [rows]="4" [(ngModel)]="room.description"></ion-textarea>
-          </div>
+        <app-html-editor [content]="room.description" [editMode]="false"></app-html-editor>
         </ion-card-content>
       </ion-card>
     </ng-container>

--- a/front-end/src/app/tabs/rooms/rooms.service.ts
+++ b/front-end/src/app/tabs/rooms/rooms.service.ts
@@ -15,7 +15,9 @@ export class RoomsService {
   constructor(private api: IDEAApiService) {}
 
   private async loadList(venue?: string): Promise<void> {
-    this.rooms = (await this.api.getResource(['rooms'], { params: { venue } })).map(r => new Room(r));
+    const params: any = {}
+    if (venue) params.venue = venue
+    this.rooms = (await this.api.getResource(['rooms'], { params })).map(r => new Room(r));
   }
 
   /**

--- a/front-end/src/app/tabs/sessions/manageSession.component.ts
+++ b/front-end/src/app/tabs/sessions/manageSession.component.ts
@@ -173,7 +173,6 @@ export class ManageSessionComponent implements OnInit {
   }
 
   addSpeaker(ev: any): void {
-    console.log('EVENT', ev)
     const speaker = ev?.detail?.value
     if (!speaker) return
 

--- a/front-end/src/app/tabs/sessions/manageSession.component.ts
+++ b/front-end/src/app/tabs/sessions/manageSession.component.ts
@@ -124,7 +124,7 @@ import { RoomLinked } from '@models/room.model';
         </ion-list-header>
         <ion-item [class.fieldHasError]="hasFieldAnError('room')">
           <ion-label position="stacked">{{ 'SESSIONS.ROOM' | translate }}</ion-label>
-          <ion-select interface="popover" [(ngModel)]="session.room">
+          <ion-select interface="popover" [(ngModel)]="session.room" [placeholder]="session?.room?.name">
             <ion-select-option *ngFor="let room of rooms" [value]="room">
               {{ room.name }}
             </ion-select-option>

--- a/front-end/src/app/tabs/sessions/manageSession.component.ts
+++ b/front-end/src/app/tabs/sessions/manageSession.component.ts
@@ -54,21 +54,23 @@ import { RoomLinked } from '@models/room.model';
           </ion-label>
           <ion-input [(ngModel)]="session.name"></ion-input>
         </ion-item>
-        <ion-item>
-          <ion-label position="stacked">{{ 'SESSIONS.TYPE' | translate }}</ion-label>
+        <ion-item [class.fieldHasError]="hasFieldAnError('type')">
+          <ion-label position="stacked">
+            {{ 'SESSIONS.TYPE' | translate }}
+            <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
           <ion-select interface="popover" [(ngModel)]="session.type">
             <ion-select-option *ngFor="let type of types | keyvalue" [value]="type.value">
               {{ 'SESSIONS.TYPES.' + type.key | translate }}
             </ion-select-option>
           </ion-select>
         </ion-item>
-        <ion-item lines="none">
-          <ion-label position="stacked">{{ 'SESSIONS.STARTS_AT' }} <ion-text class="obligatoryDot" /></ion-label>
-          <input
-            #dateTime
-            type="datetime-local"
-            [(ngModel)]="session.startsAt"
-          />
+        <ion-item lines="none" [class.fieldHasError]="hasFieldAnError('durationMinutes')">
+          <ion-label position="stacked">
+            {{ 'SESSIONS.STARTS_AT' | translate }}
+            <ion-text class="obligatoryDot" />
+          </ion-label>
+          <input #dateTime type="datetime-local" [(ngModel)]="session.startsAt" />
         </ion-item>
         <ion-item [class.fieldHasError]="hasFieldAnError('durationMinutes')">
           <ion-label position="stacked">
@@ -84,7 +86,10 @@ import { RoomLinked } from '@models/room.model';
         </ion-item>
         <ion-list-header>
           <ion-label>
-            <h4>{{ 'SESSIONS.SPEAKERS' | translate }}</h4>
+            <h4>
+              {{ 'SESSIONS.SPEAKERS' | translate }}
+              <ion-text class="obligatoryDot"></ion-text>
+            </h4>
           </ion-label>
         </ion-list-header>
         @if (session.speakers?.length) {
@@ -92,7 +97,7 @@ import { RoomLinked } from '@models/room.model';
           <ion-icon slot="start" name="mic" />
           <ion-label>{{ speaker.name }}</ion-label>
           <ion-button fill="clear" slot="end" color="danger" (click)="removeSpeaker(speaker)">
-            <ion-icon slot="icon-only" name="trash"/>
+            <ion-icon slot="icon-only" name="trash" />
           </ion-button>
         </ion-item>
         } @else {
@@ -101,7 +106,7 @@ import { RoomLinked } from '@models/room.model';
           <ion-label>{{ 'SESSIONS.NO_SPEAKERS' | translate }}</ion-label>
         </ion-item>
         }
-        <ion-item [class.fieldHasError]="hasFieldAnError('speaker')">
+        <ion-item [class.fieldHasError]="hasFieldAnError('speakers')">
           <ion-label position="stacked">{{ 'SESSIONS.ADD_SPEAKER' | translate }}</ion-label>
           <ion-select interface="popover" (ionChange)="addSpeaker($event)">
             <ion-select-option *ngFor="let speaker of speakers" [value]="speaker">
@@ -111,7 +116,10 @@ import { RoomLinked } from '@models/room.model';
         </ion-item>
         <ion-list-header>
           <ion-label>
-            <h4>{{ 'SESSIONS.ROOM' | translate }}</h4>
+            <h4>
+              {{ 'SESSIONS.ROOM' | translate }}
+              <ion-text class="obligatoryDot"></ion-text>
+            </h4>
           </ion-label>
         </ion-list-header>
         <ion-item [class.fieldHasError]="hasFieldAnError('room')">
@@ -173,8 +181,8 @@ export class ManageSessionComponent implements OnInit {
   }
 
   addSpeaker(ev: any): void {
-    const speaker = ev?.detail?.value
-    if (!speaker) return
+    const speaker = ev?.detail?.value;
+    if (!speaker) return;
 
     if (this.session.speakers.some(s => s.speakerId === speaker.speakerId)) return;
 

--- a/front-end/src/app/tabs/sessions/manageSession.component.ts
+++ b/front-end/src/app/tabs/sessions/manageSession.component.ts
@@ -186,6 +186,7 @@ export class ManageSessionComponent implements OnInit {
   }
 
   async save(): Promise<void> {
+    this.session = new Session(this.session);
     this.errors = new Set(this.session.validate());
     if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
 

--- a/front-end/src/app/tabs/sessions/manageSession.component.ts
+++ b/front-end/src/app/tabs/sessions/manageSession.component.ts
@@ -1,0 +1,234 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { AlertController, IonicModule, ModalController } from '@ionic/angular';
+import {
+  IDEALoadingService,
+  IDEAMessageService,
+  IDEATranslationsModule,
+  IDEATranslationsService
+} from '@idea-ionic/common';
+
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
+import { AppService } from '@app/app.service';
+import { SpeakersService } from '../speakers/speakers.service';
+import { RoomsService } from '../rooms/rooms.service';
+import { SessionsService } from './sessions.service';
+
+import { SpeakerLinked } from '@models/speaker.model';
+import { Session, SessionType } from '@models/session.model';
+import { RoomLinked } from '@models/room.model';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
+  selector: 'app-manage-session',
+  template: `
+    <ion-header class="ion-no-border">
+      <ion-toolbar color="medium">
+        <ion-buttons slot="start">
+          <ion-button [title]="'COMMON.CANCEL' | translate" (click)="close()">
+            <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ 'SESSIONS.MANAGE_SESSION' | translate }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
+            <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content [class.ion-padding]="!app.isInMobileMode()">
+      <ion-list class="aList" lines="full">
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'SESSIONS.CODE' | translate }}
+          </ion-label>
+          <ion-input [(ngModel)]="session.code"></ion-input>
+        </ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('name')">
+          <ion-label position="stacked">
+            {{ 'SESSIONS.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input [(ngModel)]="session.name"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">{{ 'SESSIONS.TYPE' | translate }}</ion-label>
+          <ion-select interface="popover" [(ngModel)]="session.type">
+            <ion-select-option *ngFor="let type of types | keyvalue" [value]="type.value">
+              {{ 'SESSIONS.TYPES.' + type.key | translate }}
+            </ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item lines="none">
+          <ion-label position="stacked">{{ 'SESSIONS.STARTS_AT' }} <ion-text class="obligatoryDot" /></ion-label>
+          <input
+            #dateTime
+            type="datetime-local"
+            [(ngModel)]="session.startsAt"
+          />
+        </ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('durationMinutes')">
+          <ion-label position="stacked">
+            {{ 'SESSIONS.DURATION_MINUTES' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input [(ngModel)]="session.durationMinutes"></ion-input>
+        </ion-item>
+        <ion-item *ngIf="session.type !== types.COMMON" [class.fieldHasError]="hasFieldAnError('limitOfParticipants')">
+          <ion-label position="stacked">
+            {{ 'SESSIONS.PARTICIPANT_LIMIT' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input type="number" [(ngModel)]="session.limitOfParticipants"></ion-input>
+        </ion-item>
+        <ion-list-header>
+          <ion-label>
+            <h4>{{ 'SESSIONS.SPEAKERS' | translate }}</h4>
+          </ion-label>
+        </ion-list-header>
+        @if (session.speakers?.length) {
+        <ion-item *ngFor="let speaker of session.speakers">
+          <ion-icon slot="start" name="mic" />
+          <ion-label>{{ speaker.name }}</ion-label>
+          <ion-button fill="clear" slot="end" color="danger" (click)="removeSpeaker(speaker)">
+            <ion-icon slot="icon-only" name="trash"/>
+          </ion-button>
+        </ion-item>
+        } @else {
+        <ion-item [class.fieldHasError]="hasFieldAnError('speaker')">
+          <ion-icon slot="start" name="mic" />
+          <ion-label>{{ 'SESSIONS.NO_SPEAKERS' | translate }}</ion-label>
+        </ion-item>
+        }
+        <ion-item [class.fieldHasError]="hasFieldAnError('speaker')">
+          <ion-label position="stacked">{{ 'SESSIONS.ADD_SPEAKER' | translate }}</ion-label>
+          <ion-select interface="popover" (ionChange)="addSpeaker($event)">
+            <ion-select-option *ngFor="let speaker of speakers" [value]="speaker">
+              {{ speaker.name }}
+            </ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-list-header>
+          <ion-label>
+            <h4>{{ 'SESSIONS.ROOM' | translate }}</h4>
+          </ion-label>
+        </ion-list-header>
+        <ion-item [class.fieldHasError]="hasFieldAnError('room')">
+          <ion-label position="stacked">{{ 'SESSIONS.ROOM' | translate }}</ion-label>
+          <ion-select interface="popover" [(ngModel)]="session.room">
+            <ion-select-option *ngFor="let room of rooms" [value]="room">
+              {{ room.name }}
+            </ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-list-header [class.fieldHasError]="hasFieldAnError('description')">
+          <ion-label>
+            <h2>{{ 'SESSIONS.DESCRIPTION' | translate }}</h2>
+          </ion-label>
+        </ion-list-header>
+        <app-html-editor [(content)]="session.description" [editMode]="true"></app-html-editor>
+        <ion-row class="ion-padding-top" *ngIf="session.sessionId">
+          <ion-col class="ion-text-right">
+            <ion-button color="danger" (click)="askAndDelete()">{{ 'COMMON.DELETE' | translate }}</ion-button>
+          </ion-col>
+        </ion-row>
+      </ion-list>
+    </ion-content>
+  `
+})
+export class ManageSessionComponent implements OnInit {
+  /**
+   * The session to manage.
+   */
+  @Input() session: Session;
+  entityBeforeChange: Session;
+
+  types = SessionType;
+  speakers: SpeakerLinked[] = [];
+  rooms: RoomLinked[] = [];
+
+  errors = new Set<string>();
+
+  constructor(
+    private modalCtrl: ModalController,
+    private alertCtrl: AlertController,
+    private t: IDEATranslationsService,
+    private loading: IDEALoadingService,
+    private message: IDEAMessageService,
+    private _rooms: RoomsService,
+    private _speakers: SpeakersService,
+    private _sessions: SessionsService,
+    public app: AppService
+  ) {}
+
+  async ngOnInit() {
+    this.entityBeforeChange = new Session(this.session);
+    this.rooms = (await this._rooms.getList({ force: true })).map(r => new RoomLinked(r));
+    this.speakers = (await this._speakers.getList({ force: true })).map(s => new SpeakerLinked(s));
+  }
+
+  hasFieldAnError(field: string): boolean {
+    return this.errors.has(field);
+  }
+
+  addSpeaker(ev: any): void {
+    console.log('EVENT', ev)
+    const speaker = ev?.detail?.value
+    if (!speaker) return
+
+    if (this.session.speakers.some(s => s.speakerId === speaker.speakerId)) return;
+
+    this.session.speakers.push(speaker);
+  }
+
+  removeSpeaker(speaker: SpeakerLinked): void {
+    this.session.speakers = this.session.speakers.filter(s => s.speakerId !== speaker.speakerId);
+  }
+
+  async save(): Promise<void> {
+    this.errors = new Set(this.session.validate());
+    if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
+
+    try {
+      await this.loading.show();
+      let result: Session;
+      if (!this.session.sessionId) result = await this._sessions.insert(this.session);
+      else result = await this._sessions.update(this.session);
+      this.session.load(result);
+      this.message.success('COMMON.OPERATION_COMPLETED');
+      this.close();
+    } catch (err) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+  close(): void {
+    this.session = this.entityBeforeChange;
+    this.modalCtrl.dismiss();
+  }
+
+  async askAndDelete(): Promise<void> {
+    const doDelete = async (): Promise<void> => {
+      try {
+        await this.loading.show();
+        await this._sessions.delete(this.session);
+        this.message.success('COMMON.OPERATION_COMPLETED');
+        this.close();
+      } catch (error) {
+        this.message.error('COMMON.OPERATION_FAILED');
+      } finally {
+        this.loading.hide();
+      }
+    };
+    const header = this.t._('COMMON.ARE_YOU_SURE');
+    const message = this.t._('COMMON.ACTION_IS_IRREVERSIBLE');
+    const buttons = [
+      { text: this.t._('COMMON.CANCEL'), role: 'cancel' },
+      { text: this.t._('COMMON.DELETE'), role: 'destructive', handler: doDelete }
+    ];
+    const alert = await this.alertCtrl.create({ header, message, buttons });
+    alert.present();
+  }
+}

--- a/front-end/src/app/tabs/sessions/session.page.html
+++ b/front-end/src/app/tabs/sessions/session.page.html
@@ -1,0 +1,25 @@
+<ion-content>
+  <div class="maxWidthContainer">
+    <app-session-detail
+    *ngIf="session"
+    [session]="session"
+    [isSessionInFavorites]="isSessionInFavorites(session)"
+    [isUserRegisteredInSession]="isUserRegisteredInSession(session)"
+    (favorite)="toggleFavorite(session)"
+    (register)="toggleRegister(session)"
+  >
+    <ion-buttons slot="start">
+      <ion-button color="primary" (click)="app.goToInTabs(['agenda'], { back: true })">
+        <ion-icon slot="icon-only" name="arrow-back" />
+      </ion-button>
+    </ion-buttons>
+    <ion-buttons slot="end" *ngIf="session && app.user.permissions.canManageContents">
+      <ng-container>
+        <ion-button color="ESNgreen" (click)="manageSession()">
+          <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+        </ion-button>
+      </ng-container>
+    </ion-buttons>
+  </app-session-detail>
+  </div>
+</ion-content>

--- a/front-end/src/app/tabs/sessions/session.page.html
+++ b/front-end/src/app/tabs/sessions/session.page.html
@@ -5,8 +5,8 @@
     [session]="session"
     [isSessionInFavorites]="isSessionInFavorites(session)"
     [isUserRegisteredInSession]="isUserRegisteredInSession(session)"
-    (favorite)="toggleFavorite(session)"
-    (register)="toggleRegister(session)"
+    (favorite)="toggleFavorite($event, session)"
+    (register)="toggleRegister($event, session)"
   >
     <ion-buttons slot="start">
       <ion-button color="primary" (click)="app.goToInTabs(['agenda'], { back: true })">

--- a/front-end/src/app/tabs/sessions/session.page.ts
+++ b/front-end/src/app/tabs/sessions/session.page.ts
@@ -58,7 +58,8 @@ export class SessionPage implements OnInit {
     return this.favoriteSessionsIds.includes(session.sessionId);
   }
 
-  async toggleFavorite(session: Session): Promise<void> {
+  async toggleFavorite(ev: any, session: Session): Promise<void> {
+    ev?.stopPropagation()
     try {
       await this.loading.show();
       if (this.isSessionInFavorites(session)) {
@@ -79,7 +80,8 @@ export class SessionPage implements OnInit {
     return this.registeredSessionsIds.includes(session.sessionId);
   }
 
-  async toggleRegister(session: Session): Promise<void> {
+  async toggleRegister(ev: any, session: Session): Promise<void> {
+    ev?.stopPropagation()
     try {
       await this.loading.show();
       if (this.isUserRegisteredInSession(session)) {

--- a/front-end/src/app/tabs/sessions/sessionCard.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionCard.component.ts
@@ -21,6 +21,19 @@ import { Session } from '@models/session.model';
         <ion-card-header>
           <ion-card-title>{{ session.name }}</ion-card-title>
         </ion-card-header>
+        <ion-card-content>
+          <ion-item lines="none">
+            <ion-icon slot="start" name="calendar" />
+            <ion-label>
+              {{ app.formatTime(session.startsAt) }} - {{ app.formatTime(session.endsAt) }} ({{
+                app.formatDateShort(session.startsAt)
+              }})
+            </ion-label>
+            <ion-badge color="primary">
+              {{ session.code }}
+            </ion-badge>
+          </ion-item>
+        </ion-card-content>
       </ion-card>
 
       <ion-card *ngIf="!preview" color="white">
@@ -37,7 +50,7 @@ import { Session } from '@models/session.model';
           <ion-card-subtitle>{{ session.description }}</ion-card-subtitle>
         </ion-card-header>
         <ion-card-content>
-        <app-html-editor [content]="session.description" [editMode]="false"></app-html-editor>
+          <app-html-editor [content]="session.description" [editMode]="false"></app-html-editor>
         </ion-card-content>
       </ion-card>
     </ng-container>

--- a/front-end/src/app/tabs/sessions/sessionCard.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionCard.component.ts
@@ -17,7 +17,12 @@ import { Session } from '@models/session.model';
   selector: 'app-session-card',
   template: `
     <ng-container *ngIf="session; else skeletonTemplate">
-      <ion-card *ngIf="preview" [color]="preview ? 'white' : ''">
+      <ion-card
+        *ngIf="preview"
+        button
+        [color]="preview ? 'white' : ''"
+        (click)="this.app.goToInTabs(['agenda', session.sessionId])"
+      >
         <ion-card-header>
           <ion-card-title>{{ session.name }}</ion-card-title>
         </ion-card-header>
@@ -25,9 +30,8 @@ import { Session } from '@models/session.model';
           <ion-item lines="none">
             <ion-icon slot="start" name="calendar" />
             <ion-label>
-              {{ app.formatTime(session.startsAt) }} - {{ app.formatTime(session.endsAt) }} ({{
-                app.formatDateShort(session.startsAt)
-              }})
+              {{ app.formatTime(session.startsAt) }} - {{ app.formatTime(session.endsAt) }}
+              <p>({{ app.formatDateShort(session.startsAt) }})</p>
             </ion-label>
             <ion-badge color="primary">
               {{ session.code }}

--- a/front-end/src/app/tabs/sessions/sessionCard.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionCard.component.ts
@@ -5,13 +5,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { IDEATranslationsModule } from '@idea-ionic/common';
 
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
 import { AppService } from 'src/app/app.service';
 
 import { Session } from '@models/session.model';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule],
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
   selector: 'app-session-card',
   template: `
     <ng-container *ngIf="session; else skeletonTemplate">
@@ -36,9 +38,7 @@ import { Session } from '@models/session.model';
           <ion-card-subtitle>{{ session.description }}</ion-card-subtitle>
         </ion-card-header>
         <ion-card-content>
-          <div class="divDescription" *ngIf="session.description">
-            <ion-textarea readonly [rows]="4" [(ngModel)]="session.description"></ion-textarea>
-          </div>
+        <app-html-editor [content]="session.description" [editMode]="false"></app-html-editor>
         </ion-card-content>
       </ion-card>
     </ng-container>

--- a/front-end/src/app/tabs/sessions/sessionCard.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionCard.component.ts
@@ -20,7 +20,6 @@ import { Session } from '@models/session.model';
       <ion-card *ngIf="preview" [color]="preview ? 'white' : ''">
         <ion-card-header>
           <ion-card-title>{{ session.name }}</ion-card-title>
-          <ion-card-subtitle>{{ session.description }}</ion-card-subtitle>
         </ion-card-header>
       </ion-card>
 

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -45,7 +45,7 @@
       </ion-list>
       <app-html-editor [content]="session.description" [editMode]="false"></app-html-editor>
       <ion-row>
-        <ion-col *ngIf="session.requiresRegistration">
+        <ion-col *ngIf="session.requiresRegistration && app.configurations.areSessionRegistrationsOpen">
           <ion-button
             fill="clear"
             expand="block"

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -1,0 +1,75 @@
+<ion-header class="ion-no-border">
+  <ion-toolbar color="ideaToolbar">
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-card color="white">
+    <ion-card-header>
+      <ion-card-subtitle>
+        <ion-badge color="primary">
+          {{ session.code }}
+        </ion-badge>
+      </ion-card-subtitle>
+      <ion-card-title>
+        <ion-text style="font-weight: 600">
+          {{ session.name }}
+        </ion-text>
+      </ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-list lines="none">
+        <ion-item [color]="_sessions.getColourBySessionType(session)">
+          <ion-icon slot="start" name="pricetag" />
+          <ion-label>{{ 'SESSIONS.TYPES.' + session.type | translate }}</ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="time" />
+          <ion-label>{{ app.formatTime(session.startsAt) }} - {{ app.formatTime(session.endsAt) }}</ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="hourglass" />
+          <ion-label>{{ session.durationMinutes }} {{ 'COMMON.MINUTES' | translate }}</ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="location" />
+          <ion-label>{{ session.room.name }} ({{ session.room.venue.name }})</ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-icon slot="start" name="mic" />
+          <ion-label>{{ session.getSpeakers() }}</ion-label>
+        </ion-item>
+        <ion-item *ngIf="session.requiresRegistration">
+          <ion-icon slot="start" name="people" />
+          <ion-label>{{ session.isFull() ? this.t._('COMMON.FULL') : session.numberOfParticipants + '/' + session.limitOfParticipants }}</ion-label>
+        </ion-item>
+      </ion-list>
+      <app-html-editor [content]="session.description" [editMode]="false"></app-html-editor>
+      <ion-row>
+        <ion-col *ngIf="session.requiresRegistration">
+          <ion-button
+            fill="clear"
+            expand="block"
+            [disabled]="!canUserRegisterInSession"
+            [color]="isUserRegisteredInSession ? 'danger' : 'success'"
+            (click)="register.emit()"
+            >
+            <ion-icon
+            [name]="isUserRegisteredInSession ? 'close-circle' : 'checkmark-circle'"
+            slot="icon-only"
+            />
+          </ion-button>
+        </ion-col>
+        <ion-col>
+          <ion-button
+            fill="clear"
+            expand="block"
+            color="warning"
+            (click)="favorite.emit()"
+          >
+            <ion-icon [name]="isSessionInFavorites ? 'star' : 'star-outline'" slot="icon-only" />
+          </ion-button>
+        </ion-col>
+      </ion-row>
+    </ion-card-content>
+  </ion-card>
+</ion-content>

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -49,7 +49,6 @@
           <ion-button
             fill="clear"
             expand="block"
-            [disabled]="!canUserRegisterInSession"
             [color]="isUserRegisteredInSession ? 'danger' : 'success'"
             (click)="register.emit()"
             >

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -63,7 +63,7 @@
             />
           </ion-button>
         </ion-col>
-        <ion-col>
+        <ion-col *ngIf="!isUserRegisteredInSession">
           <ion-button
             fill="clear"
             expand="block"

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -39,9 +39,18 @@
           <ion-icon slot="start" name="location" />
           <ion-label>{{ session.room.name }} ({{ session.room.venue.name }})</ion-label>
         </ion-item>
-        <ion-item>
+        <ion-item class="ion-text-wrap">
           <ion-icon slot="start" name="mic" />
-          <ion-label>{{ session.getSpeakers() }}</ion-label>
+          <ion-label class="ion-text-wrap">
+            <ion-button
+            *ngFor="let speaker of session.speakers"
+            fill="outline"
+            (click)="app.goToInTabs(['speakers', speaker.speakerId])"
+            >
+              {{ speaker.name }}
+            <ion-icon size="small" slot="end" name="link" />
+          </ion-button>
+          </ion-label>
         </ion-item>
         <ion-item *ngIf="session.requiresRegistration">
           <ion-icon slot="start" name="people" />

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -1,9 +1,6 @@
-<ion-header class="ion-no-border">
-  <ion-toolbar color="ideaToolbar">
-    <ng-content></ng-content>
-  </ion-toolbar>
-</ion-header>
-<ion-content>
+<ion-toolbar color="ideaToolbar">
+  <ng-content></ng-content>
+</ion-toolbar>
   <ion-card color="white">
     <ion-card-header>
       <ion-card-subtitle>
@@ -44,6 +41,7 @@
           <ion-label class="ion-text-wrap">
             <ion-button
             *ngFor="let speaker of session.speakers"
+            class="ion-text-wrap"
             fill="outline"
             (click)="app.goToInTabs(['speakers', speaker.speakerId])"
             >
@@ -85,4 +83,3 @@
       </ion-row>
     </ion-card-content>
   </ion-card>
-</ion-content>

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -1,5 +1,6 @@
 <ion-header class="ion-no-border">
   <ion-toolbar color="ideaToolbar">
+    <ng-content></ng-content>
   </ion-toolbar>
 </ion-header>
 <ion-content>

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.html
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.html
@@ -24,6 +24,10 @@
           <ion-label>{{ 'SESSIONS.TYPES.' + session.type | translate }}</ion-label>
         </ion-item>
         <ion-item>
+          <ion-icon slot="start" name="calendar" />
+          <ion-label>{{ app.formatDateShort(session.startsAt) }}</ion-label>
+        </ion-item>
+        <ion-item>
           <ion-icon slot="start" name="time" />
           <ion-label>{{ app.formatTime(session.startsAt) }} - {{ app.formatTime(session.endsAt) }}</ion-label>
         </ion-item>

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.scss
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.scss
@@ -1,0 +1,3 @@
+ion-content {
+  max-height: 100vh;
+}

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.scss
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.scss
@@ -1,3 +1,3 @@
 ion-content {
-  height: 100vh;
+  min-height: 100vh;
 }

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.scss
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.scss
@@ -1,3 +1,3 @@
 ion-content {
-  max-height: 100vh;
+  height: 100vh;
 }

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.ts
@@ -15,7 +15,6 @@ export class SessionDetailComponent {
   @Input() session: Session;
   @Input() isSessionInFavorites: boolean;
   @Input() isUserRegisteredInSession: boolean;
-  @Input() canUserRegisterInSession: boolean;
   @Output() favorite = new EventEmitter<void>();
   @Output() register = new EventEmitter<void>();
 

--- a/front-end/src/app/tabs/sessions/sessionDetail.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionDetail.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+import { AppService } from '@app/app.service';
+import { IDEATranslationsService } from '@idea-ionic/common';
+
+import { Session } from '@models/session.model';
+import { SessionsService } from './sessions.service';
+
+@Component({
+  selector: 'app-session-detail',
+  templateUrl: 'sessionDetail.component.html',
+  styleUrls: ['sessionDetail.component.scss']
+})
+export class SessionDetailComponent {
+  @Input() session: Session;
+  @Input() isSessionInFavorites: boolean;
+  @Input() isUserRegisteredInSession: boolean;
+  @Input() canUserRegisterInSession: boolean;
+  @Output() favorite = new EventEmitter<void>();
+  @Output() register = new EventEmitter<void>();
+
+  constructor(public _sessions: SessionsService, public t: IDEATranslationsService, public app: AppService) {}
+}

--- a/front-end/src/app/tabs/sessions/sessionItem.component.ts
+++ b/front-end/src/app/tabs/sessions/sessionItem.component.ts
@@ -1,0 +1,1 @@
+// @todo refactor items in sessions page to a component here

--- a/front-end/src/app/tabs/sessions/sessions-routing.module.ts
+++ b/front-end/src/app/tabs/sessions/sessions-routing.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { SessionsPage } from './sessions.page';
+import { SessionPage } from './session.page';
 
 const routes: Routes = [
-  { path: '', component: SessionsPage }
+  { path: '', component: SessionsPage },
+  { path: ':sessionId', component: SessionPage }
 ];
 
 @NgModule({

--- a/front-end/src/app/tabs/sessions/sessions-routing.module.ts
+++ b/front-end/src/app/tabs/sessions/sessions-routing.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { SessionsPage } from './sessions.page';
+
+const routes: Routes = [
+  { path: '', component: SessionsPage }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SessionsRoutingModule {}

--- a/front-end/src/app/tabs/sessions/sessions.module.ts
+++ b/front-end/src/app/tabs/sessions/sessions.module.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { IDEATranslationsModule } from '@idea-ionic/common';
 
 import { SessionsPage } from './sessions.page';
+import { SessionPage } from './session.page';
 import { SessionsRoutingModule } from './sessions-routing.module';
 import { SessionDetailComponent } from './sessionDetail.component';
 import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
@@ -18,6 +19,6 @@ import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
     SessionsRoutingModule,
     HTMLEditorComponent
   ],
-  declarations: [SessionsPage, SessionDetailComponent]
+  declarations: [SessionsPage, SessionPage, SessionDetailComponent]
 })
 export class SessionsModule {}

--- a/front-end/src/app/tabs/sessions/sessions.module.ts
+++ b/front-end/src/app/tabs/sessions/sessions.module.ts
@@ -6,6 +6,8 @@ import { IDEATranslationsModule } from '@idea-ionic/common';
 
 import { SessionsPage } from './sessions.page';
 import { SessionsRoutingModule } from './sessions-routing.module';
+import { SessionDetailComponent } from './sessionDetail.component';
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
 
 @NgModule({
   imports: [
@@ -13,8 +15,9 @@ import { SessionsRoutingModule } from './sessions-routing.module';
     FormsModule,
     IonicModule,
     IDEATranslationsModule,
-    SessionsRoutingModule
+    SessionsRoutingModule,
+    HTMLEditorComponent
   ],
-  declarations: [SessionsPage]
+  declarations: [SessionsPage, SessionDetailComponent]
 })
 export class SessionsModule {}

--- a/front-end/src/app/tabs/sessions/sessions.module.ts
+++ b/front-end/src/app/tabs/sessions/sessions.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+import { FormsModule } from '@angular/forms';
+import { IDEATranslationsModule } from '@idea-ionic/common';
+
+import { SessionsPage } from './sessions.page';
+import { SessionsRoutingModule } from './sessions-routing.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    IDEATranslationsModule,
+    SessionsRoutingModule
+  ],
+  declarations: [SessionsPage]
+})
+export class SessionsModule {}

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -100,7 +100,15 @@
             [isUserRegisteredInSession]="isUserRegisteredInSession(selectedSession)"
             (favorite)="toggleFavorite(selectedSession)"
             (register)="toggleRegister(selectedSession)"
-          />
+          >
+          <ion-buttons slot="end" *ngIf="selectedSession && app.user.permissions.canManageContents">
+            <ng-container>
+              <ion-button color="ESNgreen" (click)="manageSession()">
+                <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+              </ion-button>
+            </ng-container>
+          </ion-buttons>
+        </app-session-detail>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -34,7 +34,7 @@
             button
             lines="none"
             color="white"
-            (click)="openDetail(session)"
+            (click)="openDetail($event, session)"
           >
             <ion-note class="ion-text-center borderRight" slot="start">
               <b>{{ app.formatTime(session.startsAt) }}</b>
@@ -72,7 +72,7 @@
                   *ngIf="session.requiresRegistration && app.configurations.areSessionRegistrationsOpen"
                   fill="clear"
                   [color]="isUserRegisteredInSession(session) ? 'danger' : 'success'"
-                  (click)="toggleRegister(session)"
+                  (click)="toggleRegister($event, session)"
                 >
                   <ion-icon
                     [name]="isUserRegisteredInSession(session) ? 'close-circle' : 'checkmark-circle'"
@@ -83,7 +83,7 @@
                   *ngIf="!session.requiresRegistration || !app.configurations.areSessionRegistrationsOpen"
                   fill="clear"
                   color="warning"
-                  (click)="toggleFavorite(session)"
+                  (click)="toggleFavorite($event, session)"
                 >
                   <ion-icon [name]="isSessionInFavorites(session) ? 'star' : 'star-outline'" slot="icon-only" />
                 </ion-button>
@@ -98,8 +98,8 @@
             [session]="selectedSession"
             [isSessionInFavorites]="isSessionInFavorites(selectedSession)"
             [isUserRegisteredInSession]="isUserRegisteredInSession(selectedSession)"
-            (favorite)="toggleFavorite(selectedSession)"
-            (register)="toggleRegister(selectedSession)"
+            (favorite)="toggleFavorite($event, selectedSession)"
+            (register)="toggleRegister($event, selectedSession)"
           >
           <ion-buttons slot="end" *ngIf="selectedSession && app.user.permissions.canManageContents">
             <ng-container>

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -29,11 +29,13 @@
           </ion-item>
           <ion-item
             *ngFor="let session of sessions"
-            [class.favoritedSession]="!session.requiresRegistration && this.isSessionInFavorites(session)"
-            [class.registeredSession]="session.requiresRegistration && this.isUserRegisteredInSession(session)"
+            [class.unavailableSession]="!this.canUserRegisterInSession(session)"
+            [class.favoritedSession]="this.isSessionInFavorites(session)"
+            [class.registeredSession]="this.isUserRegisteredInSession(session)"
             button
             lines="none"
             color="white"
+            (click)="openDetail(session)"
           >
             <ion-note class="ion-text-center borderRight" slot="start">
               <b>{{ app.formatTime(session.startsAt) }}</b>
@@ -70,6 +72,7 @@
                 <ion-button
                   *ngIf="session.requiresRegistration"
                   fill="clear"
+                  [disabled]="!canUserRegisterInSession(session)"
                   [color]="isUserRegisteredInSession(session) ? 'danger' : 'success'"
                   (click)="toggleRegister(session)"
                 >
@@ -92,7 +95,15 @@
         </ion-list>
       </ion-col>
       <ion-col *ngIf="!app.isInMobileMode()">
-        <!-- @todo -->
+          <app-session-detail
+            *ngIf="selectedSession"
+            [session]="selectedSession"
+            [isSessionInFavorites]="isSessionInFavorites(selectedSession)"
+            [isUserRegisteredInSession]="isUserRegisteredInSession(selectedSession)"
+            [canUserRegisterInSession]="canUserRegisterInSession(selectedSession)"
+            (favorite)="toggleFavorite(selectedSession)"
+            (register)="toggleRegister(selectedSession)"
+          />
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -70,7 +70,7 @@
               </ion-chip>
               <span class="ion-text-center">
                 <ion-button
-                  *ngIf="session.requiresRegistration"
+                  *ngIf="session.requiresRegistration && app.configurations.areSessionRegistrationsOpen"
                   fill="clear"
                   [disabled]="!canUserRegisterInSession(session)"
                   [color]="isUserRegisteredInSession(session) ? 'danger' : 'success'"
@@ -82,7 +82,7 @@
                   />
                 </ion-button>
                 <ion-button
-                  *ngIf="!session.requiresRegistration"
+                  *ngIf="!session.requiresRegistration || !app.configurations.areSessionRegistrationsOpen"
                   fill="clear"
                   color="warning"
                   (click)="toggleFavorite(session)"

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -1,0 +1,99 @@
+<ion-header>
+  <ion-toolbar *ngIf="app.isInMobileMode()" color="ideaToolbar">
+    <ion-title class="ion-text-center">
+      {{ 'SESSIONS.LIST' | translate }}
+    </ion-title>
+  </ion-toolbar>
+</ion-header>
+<ion-content>
+  <ion-grid>
+    <ion-row>
+      <ion-col [size]="app.isInMobileMode() ? 12 : 6">
+        <ion-segment [(ngModel)]="segment">
+          <ion-segment-button [value]="''" (click)="changeSegment('', searchbar.value)">
+            <ion-icon name="star" />
+          </ion-segment-button>
+          <ion-segment-button *ngFor="let day of days" [value]="day" (click)="changeSegment(day, searchbar.value)">
+            <ion-label>
+              {{ app.formatDateShort(day) }}
+            </ion-label>
+          </ion-segment-button>
+        </ion-segment>
+        <ion-list class="maxWidthContainer" lines="inset">
+          <ion-searchbar #searchbar color="light" (ionInput)="filterSessions($event.target.value)"></ion-searchbar>
+          <ion-item color="white" class="noElements" *ngIf="sessions && !sessions.length">
+            <ion-label>{{ 'COMMON.NO_ELEMENT_FOUND' | translate }}</ion-label>
+          </ion-item>
+          <ion-item color="white" *ngIf="!sessions">
+            <ion-label><ion-skeleton-text animated></ion-skeleton-text></ion-label>
+          </ion-item>
+          <ion-item
+            *ngFor="let session of sessions"
+            [class.favoritedSession]="!session.requiresRegistration && this.isSessionInFavorites(session)"
+            [class.registeredSession]="session.requiresRegistration && this.isUserRegisteredInSession(session)"
+            button
+            lines="none"
+            color="white"
+          >
+            <ion-note class="ion-text-center borderRight" slot="start">
+              <b>{{ app.formatTime(session.startsAt) }}</b>
+              <span>{{ app.formatTime(session.endsAt) }}</span>
+            </ion-note>
+            <ion-label class="ion-text-wrap">
+              <ion-text class="sessionTitle">{{ session.name }}</ion-text>
+              <p>
+                <ion-badge [color]="_sessions.getColourBySessionType(session)">
+                  {{ 'SESSIONS.TYPES.' + session.type | translate }}
+                </ion-badge>
+              </p>
+              <p>
+                <ion-icon color="medium" name="location-outline"/>
+                <ion-text color="medium">
+                  {{ session.room.name }} ({{ session.room.venue.name }})
+                </ion-text>
+                <br />
+                <ion-icon color="medium" name="mic-outline"/>
+                <ion-text color="medium">
+                  {{ session.getSpeakers() }}
+                </ion-text>
+              </p>
+            </ion-label>
+            <ion-note class="ion-text-center" slot="end">
+              <ion-chip outline [color]="session.isFull() ? 'danger' : 'primary'">
+                @if(session.requiresRegistration) {
+                  {{ session.isFull() ? this.t._('COMMON.FULL') : session.numberOfParticipants + '/' + session.limitOfParticipants }}
+                } @else {
+                  {{ 'COMMON.OPEN' | translate }}
+                }
+              </ion-chip>
+              <span class="ion-text-center">
+                <ion-button
+                  *ngIf="session.requiresRegistration"
+                  fill="clear"
+                  [color]="isUserRegisteredInSession(session) ? 'danger' : 'success'"
+                  (click)="toggleRegister(session)"
+                >
+                  <ion-icon
+                    [name]="isUserRegisteredInSession(session) ? 'close-circle' : 'checkmark-circle'"
+                    slot="icon-only"
+                  />
+                </ion-button>
+                <ion-button
+                  *ngIf="!session.requiresRegistration"
+                  fill="clear"
+                  color="warning"
+                  (click)="toggleFavorite(session)"
+                >
+                  <ion-icon [name]="isSessionInFavorites(session) ? 'star' : 'star-outline'" slot="icon-only" />
+                </ion-button>
+              </span>
+            </ion-note>
+          </ion-item>
+        </ion-list>
+      </ion-col>
+      <ion-col *ngIf="!app.isInMobileMode()">
+        <!-- @todo -->
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</ion-content>

--- a/front-end/src/app/tabs/sessions/sessions.page.html
+++ b/front-end/src/app/tabs/sessions/sessions.page.html
@@ -29,7 +29,6 @@
           </ion-item>
           <ion-item
             *ngFor="let session of sessions"
-            [class.unavailableSession]="!this.canUserRegisterInSession(session)"
             [class.favoritedSession]="this.isSessionInFavorites(session)"
             [class.registeredSession]="this.isUserRegisteredInSession(session)"
             button
@@ -72,7 +71,6 @@
                 <ion-button
                   *ngIf="session.requiresRegistration && app.configurations.areSessionRegistrationsOpen"
                   fill="clear"
-                  [disabled]="!canUserRegisterInSession(session)"
                   [color]="isUserRegisteredInSession(session) ? 'danger' : 'success'"
                   (click)="toggleRegister(session)"
                 >
@@ -100,7 +98,6 @@
             [session]="selectedSession"
             [isSessionInFavorites]="isSessionInFavorites(selectedSession)"
             [isUserRegisteredInSession]="isUserRegisteredInSession(selectedSession)"
-            [canUserRegisterInSession]="canUserRegisterInSession(selectedSession)"
             (favorite)="toggleFavorite(selectedSession)"
             (register)="toggleRegister(selectedSession)"
           />

--- a/front-end/src/app/tabs/sessions/sessions.page.scss
+++ b/front-end/src/app/tabs/sessions/sessions.page.scss
@@ -9,11 +9,6 @@ ion-item {
   margin: 8;
 }
 
-.unavailableSession {
-  border-color: var(--ion-color-danger);
-  border-style: solid ;
-}
-
 .registeredSession.favoritedSession {
   border-color: var(--ion-color-primary);
   border-style: solid ;

--- a/front-end/src/app/tabs/sessions/sessions.page.scss
+++ b/front-end/src/app/tabs/sessions/sessions.page.scss
@@ -1,12 +1,22 @@
+ion-list {
+  overflow-y: auto;
+  max-height: 100vh;
+}
+
 ion-item {
   box-shadow: '0 0 5px 3px rgba(0, 0, 0, 0.05)';
   border-radius: 12px;
   margin: 8;
 }
 
-.registeredSession {
+.unavailableSession {
+  border-color: var(--ion-color-danger);
+  border-style: solid ;
+}
+
+.registeredSession.favoritedSession {
   border-color: var(--ion-color-primary);
-  border-style: solid;
+  border-style: solid ;
 }
 
 .favoritedSession {

--- a/front-end/src/app/tabs/sessions/sessions.page.scss
+++ b/front-end/src/app/tabs/sessions/sessions.page.scss
@@ -1,0 +1,57 @@
+ion-item {
+  box-shadow: '0 0 5px 3px rgba(0, 0, 0, 0.05)';
+  border-radius: 12px;
+  margin: 8;
+}
+
+.registeredSession {
+  border-color: var(--ion-color-primary);
+  border-style: solid;
+}
+
+.favoritedSession {
+  border-color: var(--ion-color-warning);
+  border-style: solid;
+}
+
+ion-label {
+  margin-top: 0px;
+  padding-top: 0px;
+}
+
+.sessionTitle {
+  font-weight: 600;
+}
+
+.borderRight {
+  border-right-style: solid;
+}
+
+ion-note {
+  margin-top: auto;
+  margin-bottom: auto;
+
+  b, span {
+    display: block;
+    padding: 5px;
+    margin: 0px
+  }
+}
+
+ion-badge {
+  margin-top: 2;
+  font-size: '0.8em';
+}
+
+p {
+  ion-icon {
+    vertical-align: middle;
+  }
+}
+
+ion-searchbar {
+  margin-left: 0;
+  margin-right: 0;
+  padding-left: 0;
+  padding-right: 0;
+}

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -109,13 +109,13 @@ export class SessionsPage implements OnInit {
       session.numberOfParticipants = updatedSession.numberOfParticipants;
     } catch (error) {
       if (error.message === "User can't sign up for this session!"){
-        this.message.error(this.t._('SESSIONS.CANT_SIGN_UP'));
+        this.message.error('SESSIONS.CANT_SIGN_UP');
       } else if (error.message === 'Registrations are closed!'){
-        this.message.error(this.t._('SESSIONS.REGISTRATION_CLOSED'));
+        this.message.error('SESSIONS.REGISTRATION_CLOSED');
       } else if (error.message === 'Session is full! Refresh your page.'){
-        this.message.error(this.t._('SESSIONS.SESSION_FULL'));
+        this.message.error('SESSIONS.SESSION_FULL');
       } else if (error.message === 'You have 1 or more sessions during this time period.'){
-        this.message.error(this.t._('SESSIONS.OVERLAP'));
+        this.message.error('SESSIONS.OVERLAP');
       } else this.message.error('COMMON.OPERATION_FAILED');
     } finally {
       this.loading.hide();

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -19,10 +19,14 @@ export class SessionsPage implements OnInit {
 
   // @todo check if registrations are open
 
+  // @todo prevent default on favorite/register/selectDetail not working
+  // @todo if few sessions (i.e. favorites) session detail is small
+
   days: string[]
   sessions: Session[];
   favoriteSessionsIds: string[] = [];
-  registeredSessionsIds: string[] = []
+  registeredSessionsIds: string[] = [];
+  selectedSession: Session;
 
   segment = ''
 
@@ -54,7 +58,8 @@ export class SessionsPage implements OnInit {
     }
   }
   changeSegment (segment: string, search = ''): void {
-    this.segment = segment
+    this.selectedSession = null;
+    this.segment = segment;
     this.filterSessions(search);
   };
   async filterSessions(search = ''): Promise<void> {
@@ -90,6 +95,7 @@ export class SessionsPage implements OnInit {
   async toggleRegister(session: Session): Promise<void> {
     try {
       await this.loading.show();
+      // @todo we should update the session after the call, or maybe all so the user can see the current limits
       if (this.isUserRegisteredInSession(session)) {
         await this._sessions.unregisterFromSession(session.sessionId);
         this.favoriteSessionsIds = this.favoriteSessionsIds.filter(id => id !== session.sessionId);
@@ -103,19 +109,23 @@ export class SessionsPage implements OnInit {
         session.numberOfParticipants++;
       };
     } catch (error) {
+      // @todo handle errors coming from back-end
       this.message.error('COMMON.OPERATION_FAILED');
     } finally {
       this.loading.hide();
     }
   }
 
-  // @todo this may be refactored to use both on back-end and front-end. This will handle the logic to tell if a session is disabled or not. WARNING IS DISABLED YOU CANT OPEN DETAIL....
+  // @todo this may be refactored to use both on back-end and front-end. This will handle the logic to tell if a session is disabled or not.
   canUserRegisterInSession(session: Session) {
-    if (session.isFull()) return false;
-
-    // @todo or should this just disable the button and make the border red...?
+    if (!session.requiresRegistration) return true;
     // @todo check logic to avoid overlaps.
+    return true;
   }
 
-  // @todo open detail <- modal if mobile, selectSession if not
+  openDetail(session: Session): void {
+    // @todo if mobile, show on modal
+    if (this.app.isInMobileMode()) return;
+    this.selectedSession = session;
+  }
 }

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -100,18 +100,23 @@ export class SessionsPage implements OnInit {
         this.favoriteSessionsIds = this.favoriteSessionsIds.filter(id => id !== session.sessionId);
         this.registeredSessionsIds = this.registeredSessionsIds.filter(id => id !== session.sessionId);
         if (!this.segment) this.sessions = this.sessions.filter(s => s.sessionId !== session.sessionId);
-        // session.numberOfParticipants--;
       } else {
         await this._sessions.registerInSession(session.sessionId);
         this.favoriteSessionsIds.push(session.sessionId);
         this.registeredSessionsIds.push(session.sessionId);
-        // session.numberOfParticipants++;
       };
       const updatedSession = await this._sessions.getById(session.sessionId);
       session.numberOfParticipants = updatedSession.numberOfParticipants;
     } catch (error) {
-      // @todo handle errors coming from back-end
-      this.message.error('COMMON.OPERATION_FAILED');
+      if (error.message === "User can't sign up for this session!"){
+        this.message.error(this.t._('SESSIONS.CANT_SIGN_UP'));
+      } else if (error.message === 'Registrations are closed!'){
+        this.message.error(this.t._('SESSIONS.REGISTRATION_CLOSED'));
+      } else if (error.message === 'Session is full! Refresh your page.'){
+        this.message.error(this.t._('SESSIONS.SESSION_FULL'));
+      } else if (error.message === 'You have 1 or more sessions during this time period.'){
+        this.message.error(this.t._('SESSIONS.OVERLAP'));
+      } else this.message.error('COMMON.OPERATION_FAILED');
     } finally {
       this.loading.hide();
     }

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -1,0 +1,121 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { IonContent, IonSearchbar } from '@ionic/angular';
+
+import { AppService } from 'src/app/app.service';
+import { IDEALoadingService, IDEAMessageService, IDEATranslationsService } from '@idea-ionic/common';
+
+import { SessionsService } from './sessions.service';
+
+import { Session } from '@models/session.model';
+
+@Component({
+  selector: 'app-sessions',
+  templateUrl: './sessions.page.html',
+  styleUrls: ['./sessions.page.scss']
+})
+export class SessionsPage implements OnInit {
+  @ViewChild(IonContent) content: IonContent;
+  @ViewChild(IonContent) searchbar: IonSearchbar;
+
+  // @todo check if registrations are open
+
+  days: string[]
+  sessions: Session[];
+  favoriteSessionsIds: string[] = [];
+  registeredSessionsIds: string[] = []
+
+  segment = ''
+
+  constructor(
+    private loading: IDEALoadingService,
+    private message: IDEAMessageService,
+    public _sessions: SessionsService,
+    public t: IDEATranslationsService,
+    public app: AppService
+  ) {}
+
+  ngOnInit() {
+    // this.app.configurations.areSessionRegistrationsOpen // @todo use this in the code (and in back-end as well!!)
+    this.loadData();
+  }
+
+  async loadData() {
+    try {
+      await this.loading.show();
+      // WARNING: do not pass any segment in order to get the favorites on the next api call.
+      this.sessions = await this._sessions.getList({ force: true });
+      this.favoriteSessionsIds = this.sessions.map( s => s.sessionId);
+      this.registeredSessionsIds = (await this._sessions.loadUserRegisteredSessions()).map(ur => ur.sessionId);
+      this.days = await this._sessions.getSessionDays()
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+  changeSegment (segment: string, search = ''): void {
+    this.segment = segment
+    this.filterSessions(search);
+  };
+  async filterSessions(search = ''): Promise<void> {
+    this.sessions = await this._sessions.getList({ search, segment: this.segment });
+  }
+
+  isSessionInFavorites(session: Session): boolean {
+    return this.favoriteSessionsIds.includes(session.sessionId);
+  }
+
+  async toggleFavorite(session: Session): Promise<void> {
+    try {
+      await this.loading.show();
+      if (this.isSessionInFavorites(session)) {
+        await this._sessions.removeFromFavorites(session.sessionId);
+        this.favoriteSessionsIds = this.favoriteSessionsIds.filter(id => id !== session.sessionId);
+        if (!this.segment) this.sessions = this.sessions.filter(s => s.sessionId !== session.sessionId);
+      } else {
+        await this._sessions.addToFavorites(session.sessionId);
+        this.favoriteSessionsIds.push(session.sessionId);
+      };
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+
+  isUserRegisteredInSession(session: Session): boolean {
+    return this.registeredSessionsIds.includes(session.sessionId);
+  }
+
+  async toggleRegister(session: Session): Promise<void> {
+    try {
+      await this.loading.show();
+      if (this.isUserRegisteredInSession(session)) {
+        await this._sessions.unregisterFromSession(session.sessionId);
+        this.favoriteSessionsIds = this.favoriteSessionsIds.filter(id => id !== session.sessionId);
+        this.registeredSessionsIds = this.registeredSessionsIds.filter(id => id !== session.sessionId);
+        if (!this.segment) this.sessions = this.sessions.filter(s => s.sessionId !== session.sessionId);
+        session.numberOfParticipants--;
+      } else {
+        await this._sessions.registerInSession(session.sessionId);
+        this.favoriteSessionsIds.push(session.sessionId);
+        this.registeredSessionsIds.push(session.sessionId);
+        session.numberOfParticipants++;
+      };
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+
+  // @todo this may be refactored to use both on back-end and front-end. This will handle the logic to tell if a session is disabled or not. WARNING IS DISABLED YOU CANT OPEN DETAIL....
+  canUserRegisterInSession(session: Session) {
+    if (session.isFull()) return false;
+
+    // @todo or should this just disable the button and make the border red...?
+    // @todo check logic to avoid overlaps.
+  }
+
+  // @todo open detail <- modal if mobile, selectSession if not
+}

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -95,19 +95,20 @@ export class SessionsPage implements OnInit {
   async toggleRegister(session: Session): Promise<void> {
     try {
       await this.loading.show();
-      // @todo we should update the session after the call, or maybe all so the user can see the current limits
       if (this.isUserRegisteredInSession(session)) {
         await this._sessions.unregisterFromSession(session.sessionId);
         this.favoriteSessionsIds = this.favoriteSessionsIds.filter(id => id !== session.sessionId);
         this.registeredSessionsIds = this.registeredSessionsIds.filter(id => id !== session.sessionId);
         if (!this.segment) this.sessions = this.sessions.filter(s => s.sessionId !== session.sessionId);
-        session.numberOfParticipants--;
+        // session.numberOfParticipants--;
       } else {
         await this._sessions.registerInSession(session.sessionId);
         this.favoriteSessionsIds.push(session.sessionId);
         this.registeredSessionsIds.push(session.sessionId);
-        session.numberOfParticipants++;
+        // session.numberOfParticipants++;
       };
+      const updatedSession = await this._sessions.getById(session.sessionId);
+      session.numberOfParticipants = updatedSession.numberOfParticipants;
     } catch (error) {
       // @todo handle errors coming from back-end
       this.message.error('COMMON.OPERATION_FAILED');

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -116,13 +116,6 @@ export class SessionsPage implements OnInit {
     }
   }
 
-  // @todo this may be refactored to use both on back-end and front-end. This will handle the logic to tell if a session is disabled or not.
-  canUserRegisterInSession(session: Session) {
-    if (!session.requiresRegistration) return true;
-    // @todo check logic to avoid overlaps.
-    return true;
-  }
-
   openDetail(session: Session): void {
     // @todo if mobile, show on modal
     if (this.app.isInMobileMode()) return;

--- a/front-end/src/app/tabs/sessions/sessions.page.ts
+++ b/front-end/src/app/tabs/sessions/sessions.page.ts
@@ -19,8 +19,6 @@ export class SessionsPage {
   @ViewChild(IonContent) content: IonContent;
   @ViewChild(IonContent) searchbar: IonSearchbar;
 
-  // @todo prevent default on favorite/register/selectDetail not working
-  // @todo if few sessions (i.e. favorites) session detail is small
 
   days: string[]
   sessions: Session[];
@@ -71,7 +69,8 @@ export class SessionsPage {
     return this.favoriteSessionsIds.includes(session.sessionId);
   }
 
-  async toggleFavorite(session: Session): Promise<void> {
+  async toggleFavorite(ev: any, session: Session): Promise<void> {
+    ev?.stopPropagation()
     try {
       await this.loading.show();
       if (this.isSessionInFavorites(session)) {
@@ -93,7 +92,8 @@ export class SessionsPage {
     return this.registeredSessionsIds.includes(session.sessionId);
   }
 
-  async toggleRegister(session: Session): Promise<void> {
+  async toggleRegister(ev: any, session: Session): Promise<void> {
+    ev?.stopPropagation()
     try {
       await this.loading.show();
       if (this.isUserRegisteredInSession(session)) {
@@ -123,7 +123,9 @@ export class SessionsPage {
     }
   }
 
-  openDetail(session: Session): void {
+  openDetail(ev: any, session: Session): void {
+    ev?.stopPropagation()
+
     if (this.app.isInMobileMode()) this.app.goToInTabs(['agenda', session.sessionId]);
     else this.selectedSession = session;
   }

--- a/front-end/src/app/tabs/sessions/sessions.service.ts
+++ b/front-end/src/app/tabs/sessions/sessions.service.ts
@@ -89,7 +89,7 @@ export class SessionsService {
       search
         .split(' ')
         .every(searchTerm =>
-          [x.sessionId, x.code, x.name].filter(f => f).some(f => f.toLowerCase().includes(searchTerm))
+          [x.sessionId, x.code, x.name, x.getSpeakers()].filter(f => f).some(f => f.toLowerCase().includes(searchTerm))
         )
     );
 

--- a/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
+++ b/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
@@ -1,0 +1,217 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { AlertController, IonicModule, ModalController } from '@ionic/angular';
+import {
+  IDEALoadingService,
+  IDEAMessageService,
+  IDEATranslationsModule,
+  IDEATranslationsService
+} from '@idea-ionic/common';
+
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
+import { AppService } from '@app/app.service';
+import { MediaService } from 'src/app/common/media.service';
+import { SpeakersService } from './speakers.service';
+import { OrganizationsService } from '../organizations/organizations.service';
+
+import { OrganizationLinked } from '@models/organization.model';
+import { Speaker } from '@models/speaker.model';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
+  selector: 'app-manage-speaker',
+  template: `
+    <ion-header class="ion-no-border">
+      <ion-toolbar color="medium">
+        <ion-buttons slot="start">
+          <ion-button [title]="'COMMON.CANCEL' | translate" (click)="close()">
+            <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ 'SPEAKERS.MANAGE_SPEAKER' | translate }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
+            <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content [class.ion-padding]="!app.isInMobileMode()">
+      <ion-list class="aList" lines="full">
+        <ion-item [class.fieldHasError]="hasFieldAnError('name')">
+          <ion-label position="stacked">
+            {{ 'SPEAKERS.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input [(ngModel)]="speaker.name"></ion-input>
+        </ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('imageURL')">
+          <ion-label position="stacked">{{ 'SPEAKERS.IMAGE_URL' | translate }}</ion-label>
+          <ion-input [(ngModel)]="speaker.imageURI"></ion-input>
+          <input type="file" accept="image/*" style="display: none" id="upload-image" (change)="uploadImage($event)" />
+          <ion-button
+            slot="end"
+            fill="clear"
+            color="medium"
+            class="ion-margin-top"
+            (click)="browseImagesForElementId('upload-image')"
+          >
+            <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ion-item>
+        <ion-item  [class.fieldHasError]="hasFieldAnError('organization')">
+          <ion-label position="stacked">{{ 'SPEAKERS.ORGANIZATION' | translate }}</ion-label>
+          <ion-select interface="popover" [(ngModel)]="speaker.organization">
+            <ion-select-option *ngFor="let organization of organizations" [value]="organization">
+              {{ organization.name }}
+            </ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'SPEAKERS.TITLE' | translate }}
+          </ion-label>
+          <ion-input [(ngModel)]="speaker.title"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'SPEAKERS.EMAIL' | translate }}
+          </ion-label>
+          <ion-input [(ngModel)]="speaker.contactEmail"></ion-input>
+        </ion-item>
+        <ion-list-header>
+          <ion-label>
+            <h2>{{ 'SPEAKERS.SOCIAL_MEDIA' | translate }}</h2>
+          </ion-label>
+        </ion-list-header>
+        <ion-item>
+          <ion-icon name="logo-linkedin" slot="start" />
+          <ion-input [(ngModel)]="speaker.socialMedia.linkedIn"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-icon name="logo-instagram" slot="start" />
+          <ion-input [(ngModel)]="speaker.socialMedia.instagram"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-icon name="logo-twitter" slot="start" />
+          <ion-input [(ngModel)]="speaker.socialMedia.twitter"></ion-input>
+        </ion-item>
+        <ion-list-header [class.fieldHasError]="hasFieldAnError('description')">
+          <ion-label>
+            <h2>{{ 'SPEAKERS.DESCRIPTION' | translate }}</h2>
+          </ion-label>
+        </ion-list-header>
+        <app-html-editor [(content)]="speaker.description" [editMode]="true"></app-html-editor>
+        <ion-row class="ion-padding-top" *ngIf="speaker.speakerId">
+          <ion-col class="ion-text-right">
+            <ion-button color="danger" (click)="askAndDelete()">{{ 'COMMON.DELETE' | translate }}</ion-button>
+          </ion-col>
+        </ion-row>
+      </ion-list>
+    </ion-content>
+  `
+})
+export class ManageSpeakerComponent implements OnInit {
+  /**
+   * The speaker to manage.
+   */
+  @Input() speaker: Speaker;
+
+  entityBeforeChange: Speaker;
+  organizations: OrganizationLinked[] = [];
+
+  errors = new Set<string>();
+
+  constructor(
+    private modalCtrl: ModalController,
+    private alertCtrl: AlertController,
+    private t: IDEATranslationsService,
+    private loading: IDEALoadingService,
+    private message: IDEAMessageService,
+    private _media: MediaService,
+    private _organizations: OrganizationsService,
+    private _speakers: SpeakersService,
+    public app: AppService
+  ) {}
+
+  async ngOnInit() {
+    this.entityBeforeChange = new Speaker(this.speaker);
+    this.organizations = (await this._organizations.getList({ force: true })).map(o => new OrganizationLinked(o));
+  }
+
+  hasFieldAnError(field: string): boolean {
+    return this.errors.has(field);
+  }
+
+  browseImagesForElementId(elementId: string): void {
+    document.getElementById(elementId).click();
+  }
+  async uploadImage({ target }): Promise<void> {
+    const file = target.files[0];
+    if (!file) return;
+
+    try {
+      await this.loading.show();
+      const imageURI = await this._media.uploadImage(file);
+      await sleepForNumSeconds(3);
+      this.speaker.imageURI = imageURI;
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      if (target) target.value = '';
+      this.loading.hide();
+    }
+  }
+
+  async save(): Promise<void> {
+    this.errors = new Set(this.speaker.validate());
+    if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
+
+    try {
+      await this.loading.show();
+      let result: Speaker;
+      if (!this.speaker.speakerId) result = await this._speakers.insert(this.speaker);
+      else result = await this._speakers.update(this.speaker);
+      this.speaker.load(result);
+      this.message.success('COMMON.OPERATION_COMPLETED');
+      this.close();
+    } catch (err) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+  close(): void {
+    this.speaker = this.entityBeforeChange;
+    this.modalCtrl.dismiss();
+  }
+
+  async askAndDelete(): Promise<void> {
+    const doDelete = async (): Promise<void> => {
+      try {
+        await this.loading.show();
+        await this._speakers.delete(this.speaker);
+        this.message.success('COMMON.OPERATION_COMPLETED');
+        this.close();
+        this.app.goToInTabs(['speakers']);
+      } catch (error) {
+        this.message.error('COMMON.OPERATION_FAILED');
+      } finally {
+        this.loading.hide();
+      }
+    };
+    const header = this.t._('COMMON.ARE_YOU_SURE');
+    const message = this.t._('COMMON.ACTION_IS_IRREVERSIBLE');
+    const buttons = [
+      { text: this.t._('COMMON.CANCEL'), role: 'cancel' },
+      { text: this.t._('COMMON.DELETE'), role: 'destructive', handler: doDelete }
+    ];
+    const alert = await this.alertCtrl.create({ header, message, buttons });
+    alert.present();
+  }
+}
+
+const sleepForNumSeconds = (numSeconds = 1): Promise<void> =>
+  new Promise(resolve => setTimeout((): void => resolve(null), 1000 * numSeconds));

--- a/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
+++ b/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
@@ -66,7 +66,11 @@ import { Speaker } from '@models/speaker.model';
             {{ 'SPEAKERS.ORGANIZATION' | translate }}
             <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
-          <ion-select interface="popover" [(ngModel)]="speaker.organization">
+          <ion-select
+            interface="popover"
+            [(ngModel)]="speaker.organization"
+            [placeholder]="speaker?.organization?.name"
+          >
             <ion-select-option *ngFor="let organization of organizations" [value]="organization">
               {{ organization.name }}
             </ion-select-option>

--- a/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
+++ b/front-end/src/app/tabs/speakers/manageSpeaker.component.ts
@@ -61,8 +61,11 @@ import { Speaker } from '@models/speaker.model';
             <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
           </ion-button>
         </ion-item>
-        <ion-item  [class.fieldHasError]="hasFieldAnError('organization')">
-          <ion-label position="stacked">{{ 'SPEAKERS.ORGANIZATION' | translate }}</ion-label>
+        <ion-item [class.fieldHasError]="hasFieldAnError('organization')">
+          <ion-label position="stacked">
+            {{ 'SPEAKERS.ORGANIZATION' | translate }}
+            <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
           <ion-select interface="popover" [(ngModel)]="speaker.organization">
             <ion-select-option *ngFor="let organization of organizations" [value]="organization">
               {{ organization.name }}

--- a/front-end/src/app/tabs/speakers/speaker.page.html
+++ b/front-end/src/app/tabs/speakers/speaker.page.html
@@ -1,6 +1,13 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>{{ 'SPEAKERS.DETAILS' | translate }}</ion-title>
+    <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
+      <ng-container>
+        <ion-button color="ESNgreen" (click)="manageSpeaker(speaker)">
+          <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+        </ion-button>
+      </ng-container>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/front-end/src/app/tabs/speakers/speaker.page.html
+++ b/front-end/src/app/tabs/speakers/speaker.page.html
@@ -1,5 +1,10 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button color="primary" (click)="app.goToInTabs(['speakers'], { back: true })">
+        <ion-icon slot="icon-only" name="arrow-back" />
+      </ion-button>
+    </ion-buttons>
     <ion-title>{{ 'SPEAKERS.DETAILS' | translate }}</ion-title>
     <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
       <ng-container>

--- a/front-end/src/app/tabs/speakers/speaker.page.html
+++ b/front-end/src/app/tabs/speakers/speaker.page.html
@@ -39,7 +39,7 @@
             </ion-item>
           </ion-col>
           <ion-col *ngFor="let session of sessions">
-            <app-session-card [session]="session" [preview]="true" (click)="app.goToInTabs(['sessions', session.sessionId])"></app-session-card>
+            <app-session-card [session]="session" [preview]="true"></app-session-card>
           </ion-col>
         </ion-list>
       </ion-col>

--- a/front-end/src/app/tabs/speakers/speaker.page.ts
+++ b/front-end/src/app/tabs/speakers/speaker.page.ts
@@ -37,7 +37,7 @@ export class SpeakerPage implements OnInit {
       await this.loading.show();
       const speakerId = this.route.snapshot.paramMap.get('speakerId');
       this.speaker = await this._speakers.getById(speakerId);
-      this.sessions = await this._sessions.getList({ speaker: this.speaker.speakerId, force: true });
+      this.sessions = await this._sessions.getSpeakerSessions(this.speaker.speakerId)
     } catch (err) {
       this.message.error('COMMON.NOT_FOUND');
     } finally {
@@ -46,6 +46,6 @@ export class SpeakerPage implements OnInit {
   }
 
   async filterSessions(search: string = ''): Promise<void> {
-    this.sessions = await this._sessions.getList({ search, speaker: this.speaker.speakerId });
+    this.sessions = await this._sessions.getSpeakerSessions(this.speaker.speakerId, search);
   }
 }

--- a/front-end/src/app/tabs/speakers/speaker.page.ts
+++ b/front-end/src/app/tabs/speakers/speaker.page.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { ModalController } from '@ionic/angular';
 
 import { IDEALoadingService, IDEAMessageService } from '@idea-ionic/common';
+
+import { ManageSpeakerComponent } from './manageSpeaker.component';
 
 import { AppService } from 'src/app/app.service';
 import { SpeakersService } from './speakers.service';
@@ -21,6 +24,7 @@ export class SpeakerPage implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
+    private modalCtrl: ModalController,
     private loading: IDEALoadingService,
     private message: IDEAMessageService,
     private _speakers: SpeakersService,
@@ -47,5 +51,19 @@ export class SpeakerPage implements OnInit {
 
   async filterSessions(search: string = ''): Promise<void> {
     this.sessions = await this._sessions.getSpeakerSessions(this.speaker.speakerId, search);
+  }
+
+  async manageSpeaker(speaker: Speaker): Promise<void> {
+    if (!this.app.user.permissions.canManageContents) return
+
+    const modal = await this.modalCtrl.create({
+      component: ManageSpeakerComponent,
+      componentProps: { speaker },
+      backdropDismiss: false
+    });
+    modal.onDidDismiss().then(async (): Promise<void> => {
+      this.speaker = await this._speakers.getById(speaker.speakerId);
+    });
+    await modal.present();
   }
 }

--- a/front-end/src/app/tabs/speakers/speakerCard.component.ts
+++ b/front-end/src/app/tabs/speakers/speakerCard.component.ts
@@ -5,13 +5,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { IDEATranslationsModule } from '@idea-ionic/common';
 
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
 import { AppService } from 'src/app/app.service';
 
 import { Speaker } from '@models/speaker.model';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule],
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
   selector: 'app-speaker-card',
   template: `
     <ng-container *ngIf="speaker; else skeletonTemplate">
@@ -29,7 +31,11 @@ import { Speaker } from '@models/speaker.model';
           </ion-card-subtitle>
           <ion-card-title>{{ speaker.name }}</ion-card-title>
           <ion-card-subtitle>
-            <ion-button fill="clear" color="dark" (click)="app.goToInTabs(['organizations', speaker.organization.organizationId])">
+            <ion-button
+              fill="clear"
+              color="dark"
+              (click)="app.goToInTabs(['organizations', speaker.organization.organizationId])"
+            >
               {{ speaker.organization.name }}
             </ion-button>
           </ion-card-subtitle>
@@ -38,9 +44,21 @@ import { Speaker } from '@models/speaker.model';
           </ion-card-subtitle>
         </ion-card-header>
         <ion-card-content>
-          <div class="divDescription" *ngIf="speaker.description">
-            <ion-textarea readonly [rows]="4" [(ngModel)]="speaker.description"></ion-textarea>
-          </div>
+          <ion-list>
+            <ion-item *ngIf="speaker.socialMedia.linkedIn">
+              <ion-icon name="logo-linkedin" slot="start"/>
+              <ion-input [(ngModel)]="speaker.socialMedia.linkedIn"></ion-input>
+            </ion-item>
+            <ion-item *ngIf="speaker.socialMedia.instagram">
+              <ion-icon name="logo-instagram" slot="start"/>
+              <ion-input [(ngModel)]="speaker.socialMedia.instagram"></ion-input>
+            </ion-item>
+            <ion-item *ngIf="speaker.socialMedia.twitter">
+              <ion-icon name="logo-twitter" slot="start"/>
+              <ion-input [(ngModel)]="speaker.socialMedia.twitter"></ion-input>
+            </ion-item>
+            <app-html-editor [content]="speaker.description" [editMode]="false"></app-html-editor>
+          </ion-list>
         </ion-card-content>
       </ion-card>
     </ng-container>

--- a/front-end/src/app/tabs/tabs.component.html
+++ b/front-end/src/app/tabs/tabs.component.html
@@ -3,10 +3,10 @@
     <ion-tab-button (click)="app.goTo([''])">
       <ion-img [src]="app.getIcon()"></ion-img>
     </ion-tab-button>
+    <ion-tab-button tab="home">
+      <ion-label>{{ 'TABS.HOME' | translate }}</ion-label>
+    </ion-tab-button>
     <ng-container *ngIf="app?.user.spot?.paymentConfirmedAt">
-      <ion-tab-button tab="home">
-        <ion-label>{{ 'TABS.HOME' | translate }}</ion-label>
-      </ion-tab-button>
       <ion-tab-button tab="agenda">
         <ion-label>{{ 'TABS.AGENDA' | translate }}</ion-label>
       </ion-tab-button>
@@ -28,10 +28,10 @@
 
 <ion-tabs class="mobileTabs" *ngIf="app.isInMobileMode()">
   <ion-tab-bar color="ideaToolbar" slot="bottom">
+    <ion-tab-button tab="home">
+      <ion-icon icon="home"></ion-icon>
+    </ion-tab-button>
     <ng-container *ngIf="app?.user.spot?.paymentConfirmedAt">
-      <ion-tab-button tab="home">
-        <ion-icon icon="home"></ion-icon>
-      </ion-tab-button>
       <ion-tab-button tab="agenda">
         <ion-icon icon="calendar"></ion-icon>
       </ion-tab-button>

--- a/front-end/src/app/tabs/tabs.routing.module.ts
+++ b/front-end/src/app/tabs/tabs.routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { adminGuard } from '../admin.guard';
+import { manageGuard } from '../manage.guard';
 import { spotGuard } from '../spot.guard';
 
 import { TabsComponent } from './tabs.component';
@@ -19,7 +19,7 @@ const routes: Routes = [
       {
         path: 'manage',
         loadChildren: (): Promise<any> => import('./manage/manage.module').then(m => m.ManageModule),
-        canActivate: [adminGuard]
+        canActivate: [manageGuard]
       },
       {
         path: 'home',

--- a/front-end/src/app/tabs/tabs.routing.module.ts
+++ b/front-end/src/app/tabs/tabs.routing.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
+import { adminGuard } from '../admin.guard';
+import { spotGuard } from '../spot.guard';
+
 import { TabsComponent } from './tabs.component';
 
 const routes: Routes = [
@@ -8,14 +11,15 @@ const routes: Routes = [
     path: '',
     component: TabsComponent,
     children: [
-      { path: '', redirectTo: 'user', pathMatch: 'full' },
+      { path: '', redirectTo: 'home', pathMatch: 'full' },
       {
         path: 'user',
         loadChildren: (): Promise<any> => import('./user/user.module').then(m => m.UserModule)
       },
       {
         path: 'manage',
-        loadChildren: (): Promise<any> => import('./manage/manage.module').then(m => m.ManageModule)
+        loadChildren: (): Promise<any> => import('./manage/manage.module').then(m => m.ManageModule),
+        canActivate: [adminGuard]
       },
       {
         path: 'home',
@@ -23,27 +27,33 @@ const routes: Routes = [
       },
       {
         path: 'menu',
-        loadChildren: (): Promise<any> => import('./menu/menu.module').then(m => m.MenuModule)
+        loadChildren: (): Promise<any> => import('./menu/menu.module').then(m => m.MenuModule),
+        canActivate: [spotGuard]
       },
       {
         path: 'venues',
-        loadChildren: (): Promise<any> => import('./venues/venues.module').then(m => m.VenuesModule)
+        loadChildren: (): Promise<any> => import('./venues/venues.module').then(m => m.VenuesModule),
+        canActivate: [spotGuard]
       },
       {
         path: 'rooms',
-        loadChildren: (): Promise<any> => import('./rooms/rooms.module').then(m => m.RoomsModule)
+        loadChildren: (): Promise<any> => import('./rooms/rooms.module').then(m => m.RoomsModule),
+        canActivate: [spotGuard]
       },
       {
         path: 'organizations',
-        loadChildren: (): Promise<any> => import('./organizations/organizations.module').then(m => m.OrganizationsModule)
+        loadChildren: (): Promise<any> => import('./organizations/organizations.module').then(m => m.OrganizationsModule),
+        canActivate: [spotGuard]
       },
       {
         path: 'speakers',
-        loadChildren: (): Promise<any> => import('./speakers/speakers.module').then(m => m.SpeakersModule)
+        loadChildren: (): Promise<any> => import('./speakers/speakers.module').then(m => m.SpeakersModule),
+        canActivate: [spotGuard]
       },
       {
         path: 'agenda',
-        loadChildren: (): Promise<any> => import('./sessions/sessions.module').then(m => m.SessionsModule)
+        loadChildren: (): Promise<any> => import('./sessions/sessions.module').then(m => m.SessionsModule),
+        canActivate: [spotGuard]
       }
     ]
   }

--- a/front-end/src/app/tabs/tabs.routing.module.ts
+++ b/front-end/src/app/tabs/tabs.routing.module.ts
@@ -40,6 +40,10 @@ const routes: Routes = [
       {
         path: 'speakers',
         loadChildren: (): Promise<any> => import('./speakers/speakers.module').then(m => m.SpeakersModule)
+      },
+      {
+        path: 'agenda',
+        loadChildren: (): Promise<any> => import('./sessions/sessions.module').then(m => m.SessionsModule)
       }
     ]
   }

--- a/front-end/src/app/tabs/venues/manageVenue.component.ts
+++ b/front-end/src/app/tabs/venues/manageVenue.component.ts
@@ -29,7 +29,7 @@ import { Venue } from '@models/venue.model';
             <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
           </ion-button>
         </ion-buttons>
-        <ion-title>{{ 'ORGANIZATIONS.MANAGE_ORGANIZATION' | translate }}</ion-title>
+        <ion-title>{{ 'VENUES.MANAGE_VENUES' | translate }}</ion-title>
         <ion-buttons slot="end">
           <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
             <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>

--- a/front-end/src/app/tabs/venues/manageVenue.component.ts
+++ b/front-end/src/app/tabs/venues/manageVenue.component.ts
@@ -59,21 +59,21 @@ import { Venue } from '@models/venue.model';
             <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
           </ion-button>
         </ion-item>
-        <ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('address')">
           <ion-label position="stacked">
-            {{ 'VENUES.ADDRESS' | translate }}
+            {{ 'VENUES.ADDRESS' | translate }} <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
           <ion-input [(ngModel)]="venue.address"></ion-input>
         </ion-item>
-        <ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('latitude')">
           <ion-label position="stacked">
-            {{ 'VENUES.LATITUDE' | translate }}
+            {{ 'VENUES.LATITUDE' | translate }} <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
           <ion-input type="number" [(ngModel)]="venue.latitude"></ion-input>
         </ion-item>
-        <ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('longitude')">
           <ion-label position="stacked">
-            {{ 'VENUES.LONGITUDE' | translate }}
+            {{ 'VENUES.LONGITUDE' | translate }} <ion-text class="obligatoryDot"></ion-text>
           </ion-label>
           <ion-input type="number" [(ngModel)]="venue.longitude"></ion-input>
         </ion-item>

--- a/front-end/src/app/tabs/venues/manageVenue.component.ts
+++ b/front-end/src/app/tabs/venues/manageVenue.component.ts
@@ -1,0 +1,193 @@
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Component, Input, OnInit } from '@angular/core';
+import { AlertController, IonicModule, ModalController } from '@ionic/angular';
+import {
+  IDEALoadingService,
+  IDEAMessageService,
+  IDEATranslationsModule,
+  IDEATranslationsService
+} from '@idea-ionic/common';
+
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
+import { AppService } from '@app/app.service';
+import { MediaService } from 'src/app/common/media.service';
+import { VenuesService } from './venues.service';
+
+import { Venue } from '@models/venue.model';
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
+  selector: 'app-manage-venue',
+  template: `
+    <ion-header class="ion-no-border">
+      <ion-toolbar color="medium">
+        <ion-buttons slot="start">
+          <ion-button [title]="'COMMON.CANCEL' | translate" (click)="close()">
+            <ion-icon slot="icon-only" icon="close-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+        <ion-title>{{ 'ORGANIZATIONS.MANAGE_ORGANIZATION' | translate }}</ion-title>
+        <ion-buttons slot="end">
+          <ion-button [title]="'COMMON.SAVE' | translate" (click)="save()">
+            <ion-icon slot="icon-only" icon="checkmark-circle"></ion-icon>
+          </ion-button>
+        </ion-buttons>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content [class.ion-padding]="!app.isInMobileMode()">
+      <ion-list class="aList" lines="full">
+        <ion-item [class.fieldHasError]="hasFieldAnError('name')">
+          <ion-label position="stacked">
+            {{ 'VENUES.NAME' | translate }} <ion-text class="obligatoryDot"></ion-text>
+          </ion-label>
+          <ion-input [(ngModel)]="venue.name"></ion-input>
+        </ion-item>
+        <ion-item [class.fieldHasError]="hasFieldAnError('imageURL')">
+          <ion-label position="stacked">{{ 'VENUES.IMAGE_URL' | translate }}</ion-label>
+          <ion-input [(ngModel)]="venue.imageURI"></ion-input>
+          <input type="file" accept="image/*" style="display: none" id="upload-image" (change)="uploadImage($event)" />
+          <ion-button
+            slot="end"
+            fill="clear"
+            color="medium"
+            class="ion-margin-top"
+            (click)="browseImagesForElementId('upload-image')"
+          >
+            <ion-icon icon="cloud-upload-outline" slot="icon-only"></ion-icon>
+          </ion-button>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'VENUES.ADDRESS' | translate }}
+          </ion-label>
+          <ion-input [(ngModel)]="venue.address"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'VENUES.LATITUDE' | translate }}
+          </ion-label>
+          <ion-input type="number" [(ngModel)]="venue.latitude"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">
+            {{ 'VENUES.LONGITUDE' | translate }}
+          </ion-label>
+          <ion-input type="number" [(ngModel)]="venue.longitude"></ion-input>
+        </ion-item>
+        <ion-list-header [class.fieldHasError]="hasFieldAnError('description')">
+          <ion-label>
+            <h2>{{ 'VENUES.DESCRIPTION' | translate }}</h2>
+          </ion-label>
+        </ion-list-header>
+        <app-html-editor [(content)]="venue.description" [editMode]="true"></app-html-editor>
+        <ion-row class="ion-padding-top" *ngIf="venue.venueId">
+          <ion-col class="ion-text-right">
+            <ion-button color="danger" (click)="askAndDelete()">{{ 'COMMON.DELETE' | translate }}</ion-button>
+          </ion-col>
+        </ion-row>
+      </ion-list>
+    </ion-content>
+  `
+})
+export class ManageVenueComponent implements OnInit {
+  /**
+   * The venue to manage.
+   */
+  @Input() venue: Venue;
+
+  entityBeforeChange: Venue;
+
+  errors = new Set<string>();
+
+  constructor(
+    private modalCtrl: ModalController,
+    private alertCtrl: AlertController,
+    private t: IDEATranslationsService,
+    private loading: IDEALoadingService,
+    private message: IDEAMessageService,
+    private _media: MediaService,
+    private _venues: VenuesService,
+    public app: AppService
+  ) {}
+
+  async ngOnInit() {
+    this.entityBeforeChange = new Venue(this.venue);
+  }
+
+  hasFieldAnError(field: string): boolean {
+    return this.errors.has(field);
+  }
+
+  browseImagesForElementId(elementId: string): void {
+    document.getElementById(elementId).click();
+  }
+  async uploadImage({ target }): Promise<void> {
+    const file = target.files[0];
+    if (!file) return;
+
+    try {
+      await this.loading.show();
+      const imageURI = await this._media.uploadImage(file);
+      await sleepForNumSeconds(3);
+      this.venue.imageURI = imageURI;
+    } catch (error) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      if (target) target.value = '';
+      this.loading.hide();
+    }
+  }
+
+  async save(): Promise<void> {
+    this.errors = new Set(this.venue.validate());
+    if (this.errors.size) return this.message.error('COMMON.FORM_HAS_ERROR_TO_CHECK');
+
+    try {
+      await this.loading.show();
+      let result: Venue;
+      if (!this.venue.venueId) result = await this._venues.insert(this.venue);
+      else result = await this._venues.update(this.venue);
+      this.venue.load(result);
+      this.message.success('COMMON.OPERATION_COMPLETED');
+      this.close();
+    } catch (err) {
+      this.message.error('COMMON.OPERATION_FAILED');
+    } finally {
+      this.loading.hide();
+    }
+  }
+  close(): void {
+    this.venue = this.entityBeforeChange;
+    this.modalCtrl.dismiss();
+  }
+
+  async askAndDelete(): Promise<void> {
+    const doDelete = async (): Promise<void> => {
+      try {
+        await this.loading.show();
+        await this._venues.delete(this.venue);
+        this.message.success('COMMON.OPERATION_COMPLETED');
+        this.close();
+        this.app.goToInTabs(['venues']);
+      } catch (error) {
+        this.message.error('COMMON.OPERATION_FAILED');
+      } finally {
+        this.loading.hide();
+      }
+    };
+    const header = this.t._('COMMON.ARE_YOU_SURE');
+    const message = this.t._('COMMON.ACTION_IS_IRREVERSIBLE');
+    const buttons = [
+      { text: this.t._('COMMON.CANCEL'), role: 'cancel' },
+      { text: this.t._('COMMON.DELETE'), role: 'destructive', handler: doDelete }
+    ];
+    const alert = await this.alertCtrl.create({ header, message, buttons });
+    alert.present();
+  }
+}
+
+const sleepForNumSeconds = (numSeconds = 1): Promise<void> =>
+  new Promise(resolve => setTimeout((): void => resolve(null), 1000 * numSeconds));

--- a/front-end/src/app/tabs/venues/venue.page.html
+++ b/front-end/src/app/tabs/venues/venue.page.html
@@ -1,5 +1,10 @@
 <ion-header>
   <ion-toolbar>
+    <ion-buttons slot="start">
+      <ion-button color="primary" (click)="app.goToInTabs(['venues'], { back: true })">
+        <ion-icon slot="icon-only" name="arrow-back" />
+      </ion-button>
+    </ion-buttons>
     <ion-title>{{ 'VENUES.DETAILS' | translate }}</ion-title>
     <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
       <ng-container>

--- a/front-end/src/app/tabs/venues/venue.page.html
+++ b/front-end/src/app/tabs/venues/venue.page.html
@@ -1,6 +1,13 @@
 <ion-header>
   <ion-toolbar>
     <ion-title>{{ 'VENUES.DETAILS' | translate }}</ion-title>
+    <ion-buttons slot="end" *ngIf="app.user.permissions.canManageContents">
+      <ng-container>
+        <ion-button color="ESNgreen" (click)="manageVenue(venue)">
+          <ion-icon slot="icon-only" icon="hammer"></ion-icon>
+        </ion-button>
+      </ng-container>
+    </ion-buttons>
   </ion-toolbar>
 </ion-header>
 

--- a/front-end/src/app/tabs/venues/venue.page.ts
+++ b/front-end/src/app/tabs/venues/venue.page.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { ModalController } from '@ionic/angular';
 
 import { IDEALoadingService, IDEAMessageService } from '@idea-ionic/common';
+
+import { ManageVenueComponent } from './manageVenue.component';
 
 import { AppService } from 'src/app/app.service';
 import { VenuesService } from './venues.service';
@@ -21,6 +24,7 @@ export class VenuePage implements OnInit {
 
   constructor(
     private route: ActivatedRoute,
+    private modalCtrl: ModalController,
     private loading: IDEALoadingService,
     private message: IDEAMessageService,
     private _venues: VenuesService,
@@ -47,5 +51,19 @@ export class VenuePage implements OnInit {
 
   async filterRooms(search: string = ''): Promise<void> {
     this.rooms = await this._rooms.getList({ search, venue: this.venue.venueId });
+  }
+
+  async manageVenue(venue: Venue): Promise<void> {
+    if (!this.app.user.permissions.canManageContents) return
+
+    const modal = await this.modalCtrl.create({
+      component: ManageVenueComponent,
+      componentProps: { venue },
+      backdropDismiss: false
+    });
+    modal.onDidDismiss().then(async (): Promise<void> => {
+      this.venue = await this._venues.getById(venue.venueId);
+    });
+    await modal.present();
   }
 }

--- a/front-end/src/app/tabs/venues/venueCard.component.ts
+++ b/front-end/src/app/tabs/venues/venueCard.component.ts
@@ -5,13 +5,15 @@ import { IonicModule } from '@ionic/angular';
 
 import { IDEATranslationsModule } from '@idea-ionic/common';
 
+import { HTMLEditorComponent } from 'src/app/common/htmlEditor.component';
+
 import { AppService } from 'src/app/app.service';
 
 import { Venue } from '@models/venue.model';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule],
+  imports: [CommonModule, FormsModule, IonicModule, IDEATranslationsModule, HTMLEditorComponent],
   selector: 'app-venue-card',
   template: `
     <ion-card *ngIf="venue" color="white">
@@ -28,9 +30,7 @@ import { Venue } from '@models/venue.model';
             <ion-icon slot="end" name="navigate"></ion-icon>
           </ion-button>
         </div> -->
-        <div class="divDescription" *ngIf="venue.description">
-          <ion-textarea readonly [rows]="4" [(ngModel)]="venue.description"></ion-textarea>
-        </div>
+        <app-html-editor [content]="venue.description" [editMode]="false"></app-html-editor>
       </ion-card-content>
     </ion-card>
 

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -294,6 +294,7 @@
     "ALLOW_REGISTRATIONS": "Allow registrations",
     "ALLOW_EXTERNALS": "Allow externals to register",
     "ALLOW_SESSION_REGISTRATIONS": "Allow session registrations",
+    "SESSION_BUFFER": "Time interval between sessions for registration.",
     "ALLOW_COUNTRY_LEADER_ASSIGN_SPOT": "Allow country leaders to assign spots",
     "REGISTRATION_FORM": "Registration form",
     "REGISTRATION_FORM_I": "Add, manage and remove the fields requested during the registration.",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -80,7 +80,8 @@
     "DUPLICATE": "Duplicate",
     "ERROR": "Error",
     "OR": "Or",
-    "COPY": "Copy"
+    "COPY": "Copy",
+    "FULL": "Full"
   },
   "AUTH": {
     "TITLE": "Erasmus Generation Meeting",
@@ -291,6 +292,7 @@
     "REGISTRATIONS_OPTIONS_I": "Open/close the registrations and other options.",
     "ALLOW_REGISTRATIONS": "Allow registrations",
     "ALLOW_EXTERNALS": "Allow externals to register",
+    "ALLOW_SESSION_REGISTRATIONS": "Allow session registrations",
     "ALLOW_COUNTRY_LEADER_ASSIGN_SPOT": "Allow country leaders to assign spots",
     "REGISTRATION_FORM": "Registration form",
     "REGISTRATION_FORM_I": "Add, manage and remove the fields requested during the registration.",
@@ -378,5 +380,17 @@
     "LIST": "Speakers list",
     "DETAILS": "Speaker details",
     "SESSIONS": "Sessions given by this speaker"
+  },
+  "SESSIONS": {
+    "LIST": "Session list",
+    "TYPES": {
+      "DISCUSSION": "Discussion",
+      "TALK": "EG Talk",
+      "IGNITE": "Ignite Session",
+      "CAMPFIRE": "Campfire",
+      "INCUBATOR": "Incubator",
+      "HUB": "Knowledge Hub",
+      "COMMON": "Common"
+    }
   }
 }

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -289,6 +289,7 @@
     "ORGANIZATIONS": "Organisations",
     "SESSIONS": "Sessions",
     "VENUES": "Venues",
+    "ROOMS": "Rooms",
     "REGISTRATIONS_OPTIONS": "Registrations options",
     "REGISTRATIONS_OPTIONS_I": "Open/close the registrations and other options.",
     "ALLOW_REGISTRATIONS": "Allow registrations",
@@ -376,7 +377,12 @@
   "ORGANIZATIONS": {
     "LIST": "Organizations list",
     "DETAILS": "Organization details",
-    "SPEAKERS": "Speakers from this organization"
+    "SPEAKERS": "Speakers from this organization",
+    "NAME": "Name",
+    "IMAGE_URL": "Image URL",
+    "WEBSITE": "Website",
+    "EMAIL": "Contact email",
+    "DESCRIPTION": "Description"
   },
   "SPEAKERS": {
     "LIST": "Speakers list",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -365,7 +365,7 @@
     "PROCEED_TO_STRIPE": "Go to Stripe"
   },
   "VENUES": {
-    "MANAGE_VENUES": "Manage venues",
+    "MANAGE_VENUE": "Manage venue",
     "LIST": "List",
     "MAP": "Map",
     "DETAILS": "Venue's details",
@@ -378,11 +378,17 @@
     "LONGITUDE": "Longitude"
   },
   "ROOMS": {
+    "MANAGE_ROOM": "Manage room",
     "DETAILS": "Room details",
-    "SESSIONS": "Sessions hosted in this room"
+    "SESSIONS": "Sessions hosted in this room",
+    "NAME": "Name",
+    "IMAGE_URL": "Image URL",
+    "DESCRIPTION": "Description",
+    "VENUE": "Venue",
+    "INTERNAL_LOCATION": "Internal location"
   },
   "ORGANIZATIONS": {
-    "MANAGE_ORGANIZATIONS": "Manage organizations",
+    "MANAGE_ORGANIZATION": "Manage organizations",
     "LIST": "Organizations list",
     "DETAILS": "Organization details",
     "SPEAKERS": "Speakers from this organization",
@@ -393,7 +399,7 @@
     "DESCRIPTION": "Description"
   },
   "SPEAKERS": {
-    "MANAGE_SPEAKERS": "Manage speakers",
+    "MANAGE_SPEAKER": "Manage speaker",
     "LIST": "Speakers list",
     "DETAILS": "Speaker details",
     "SESSIONS": "Sessions given by this speaker",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -81,7 +81,8 @@
     "ERROR": "Error",
     "OR": "Or",
     "COPY": "Copy",
-    "FULL": "Full"
+    "FULL": "Full",
+    "MINUTES": "Minutes"
   },
   "AUTH": {
     "TITLE": "Erasmus Generation Meeting",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -368,7 +368,13 @@
     "LIST": "List",
     "MAP": "Map",
     "DETAILS": "Venue's details",
-    "ROOMS": "Venue's rooms"
+    "ROOMS": "Venue's rooms",
+    "NAME": "Name",
+    "IMAGE_URL": "Image URL",
+    "DESCRIPTION": "Description",
+    "ADDRESS": "Address",
+    "LATITUDE": "Latitude",
+    "LONGITUDE": "Longitude"
   },
   "ROOMS": {
     "DETAILS": "Room details",
@@ -387,7 +393,14 @@
   "SPEAKERS": {
     "LIST": "Speakers list",
     "DETAILS": "Speaker details",
-    "SESSIONS": "Sessions given by this speaker"
+    "SESSIONS": "Sessions given by this speaker",
+    "NAME": "Name",
+    "TITLE": "Title",
+    "ORGANIZATION": "Organization",
+    "IMAGE_URL": "Image URL",
+    "EMAIL": "Contact email",
+    "DESCRIPTION": "Description",
+    "SOCIAL_MEDIA": "Social media"
   },
   "SESSIONS": {
     "LIST": "Session list",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -412,6 +412,7 @@
     "SOCIAL_MEDIA": "Social media"
   },
   "SESSIONS": {
+    "MANAGE_SESSION": "Manage session",
     "LIST": "Session list",
     "TYPES": {
       "DISCUSSION": "Discussion",
@@ -425,6 +426,17 @@
     "CANT_SIGN_UP": "User can't sign up for this session!",
     "REGISTRATION_CLOSED": "Registrations are closed!",
     "SESSION_FULL": "Session is full! Refresh your page.",
-    "OVERLAP": "You have 1 or more sessions during this time period."
+    "OVERLAP": "You have 1 or more sessions during this time period.",
+    "CODE": "Session code",
+    "NAME": "Name",
+    "DESCRIPTION": "Description",
+    "TYPE": "Session type",
+    "STARTS_AT": "Session starts at",
+    "DURATION_MINUTES": "Session duration (minutes)",
+    "PARTICIPANT_LIMIT": "Participant limit",
+    "SPEAKERS": "Speakers",
+    "NO_SPEAKERS": "No speakers yet...",
+    "ADD_SPEAKER": "Add speaker",
+    "ROOM": "Room"
   }
 }

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -365,6 +365,7 @@
     "PROCEED_TO_STRIPE": "Go to Stripe"
   },
   "VENUES": {
+    "MANAGE_VENUES": "Manage venues",
     "LIST": "List",
     "MAP": "Map",
     "DETAILS": "Venue's details",
@@ -381,6 +382,7 @@
     "SESSIONS": "Sessions hosted in this room"
   },
   "ORGANIZATIONS": {
+    "MANAGE_ORGANIZATIONS": "Manage organizations",
     "LIST": "Organizations list",
     "DETAILS": "Organization details",
     "SPEAKERS": "Speakers from this organization",
@@ -391,6 +393,7 @@
     "DESCRIPTION": "Description"
   },
   "SPEAKERS": {
+    "MANAGE_SPEAKERS": "Manage speakers",
     "LIST": "Speakers list",
     "DETAILS": "Speaker details",
     "SESSIONS": "Sessions given by this speaker",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -393,6 +393,10 @@
       "INCUBATOR": "Incubator",
       "HUB": "Knowledge Hub",
       "COMMON": "Common"
-    }
+    },
+    "CANT_SIGN_UP": "User can't sign up for this session!",
+    "REGISTRATION_CLOSED": "Registrations are closed!",
+    "SESSION_FULL": "Session is full! Refresh your page.",
+    "OVERLAP": "You have 1 or more sessions during this time period."
   }
 }

--- a/scripts/migrate-data.sh
+++ b/scripts/migrate-data.sh
@@ -1,0 +1,74 @@
+# This script serves the purpose of migrating the data from the dev tables to the prod tables.
+# It is of the utmost importance that the data being passed is clean and consistent.
+
+C='\033[4;32m' # color
+NC='\033[0m'   # reset (no color)
+
+# set the script to exit in case of errors
+set -o errexit
+
+# STEPS:
+
+# We need first to install a specific Python script: dynamodump.
+# pip install dynamodump
+# OR
+# pip3 install dynamodump
+
+# Compile your parameters below:
+DYNAMO_DUMP_LOCATION="/opt/homebrew/lib/python3.11/site-packages/dynamodump/dynamodump.py"
+PROFILE="egm"
+REGION="eu-central-1"
+FROM="dev"
+TO="prod"
+
+VENUES_TABLE="venues"
+ROOMS_TABLE="rooms"
+ORGANIZATIONS_TABLE="organizations"
+SPEAKERS_TABLE="speakers"
+SESSIONS_TABLE="sessions"
+
+# Backup data from your old account to your device
+# The data is downloaded in the '~/dump' folder.
+
+echo -e "${C}Downloading venues table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m backup -s egm-${FROM}-api_${VENUES_TABLE}
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Downloading rooms table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m backup -s egm-${FROM}-api_${ROOMS_TABLE}
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Downloading organizations table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m backup -s egm-${FROM}-api_${ORGANIZATIONS_TABLE}
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Downloading speakers table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m backup -s egm-${FROM}-api_${SPEAKERS_TABLE}
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Downloading sessions table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m backup -s egm-${FROM}-api_${SESSIONS_TABLE}
+echo -e "${C}DONE!${NC}"
+
+
+# Restore data from your device to the tables
+
+echo -e "${C}Uploading venues table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m restore --skipThroughputUpdate -s egm-${FROM}-api_${VENUES_TABLE} -d egm-${TO}-api_${VENUES_TABLE} --dataOnly
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Uploading rooms table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m restore --skipThroughputUpdate -s egm-${FROM}-api_${ROOMS_TABLE} -d egm-${TO}-api_${ROOMS_TABLE} --dataOnly
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Uploading organizations table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m restore --skipThroughputUpdate -s egm-${FROM}-api_${ORGANIZATIONS_TABLE} -d egm-${TO}-api_${ORGANIZATIONS_TABLE} --dataOnly
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Uploading speakers table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m restore --skipThroughputUpdate -s egm-${FROM}-api_${SPEAKERS_TABLE} -d egm-${TO}-api_${SPEAKERS_TABLE} --dataOnly
+echo -e "${C}DONE!${NC}"
+echo -e "${C}Uploading sessions table${NC}"
+python3 ${DYNAMO_DUMP_LOCATION} --profile ${PROFILE} -r ${REGION} -m restore --skipThroughputUpdate -s egm-${FROM}-api_${SESSIONS_TABLE} -d egm-${TO}-api_${SESSIONS_TABLE} --dataOnly
+echo -e "${C}DONE!${NC}"
+
+
+# After moving the data you have to copy images from S3 dev to prod otherwise they are not available
+
+# you can download it using this command
+# sudo aws s3 cp --recursive s3://egm-media/ ./imagesS3 --profile egm
+
+# and then you can upload it manually form the aws console. (remember we want the images and thumbnails folder)


### PR DESCRIPTION
closes #109 
closes #111 
relates to #78 

Once merged we will do some graphical improvements and bug fixing if required and then we can merge into prod.

things to improve (this PR or a new issue):
- some @todos in the sessions page (i.e. we need to open the detail in a modal for mobile) + when pressing a button it automatically selects the session (ev.preventDefault() not working for some reason...). + other minor things.
- Some graphical improvements can be made to most lists (both entity lists as well as the lists inside entity details).
   - example: Organizations page could use a grid with ion-card dispalying the company logo. Same for Speakers
   - example: Room detail page has a list with ion-items with too much space, we can reduce margins and add more content and color to the list (session code, etc..). Also check if the links work, there is no `session/sessionId` page
 
- to ask:
   - should we hide past sessions? maybe on toggle?
   - can users favorite sessions without registering?
   - should the session detail page include a list of the participants in the session (it has the needed data for that)