### PR TITLE
Fix: solve bug to assign spot to a non registered user

### DIFF
--- a/back-end/src/handlers/eventSpots.ts
+++ b/back-end/src/handlers/eventSpots.ts
@@ -109,6 +109,7 @@ class EventSpotsRC extends ResourceController {
     }
 
     if (user.spot) throw new HandledError('User already has spot');
+    if (!user.registrationAt) throw new HandledError('User has not registered to the event');
 
     const updateSpot = {
       TableName: DDB_TABLES.eventSpots,
@@ -160,6 +161,7 @@ class EventSpotsRC extends ResourceController {
     }
 
     if (targetUser.spot) throw new HandledError('Target user already has spot');
+    if (!targetUser.registrationAt) throw new HandledError('User has not registered to the event');
 
     const updateSpot = {
       TableName: DDB_TABLES.eventSpots,

--- a/front-end/src/app/tabs/manage/users/users.page.html
+++ b/front-end/src/app/tabs/manage/users/users.page.html
@@ -35,7 +35,8 @@
         slot="start"
         color="ESNgreen"
         *ngIf="!app.user.permissions.isAdmin && canAssignSpotAsCountryLeader()"
-        [disabled]="!numCountrySpotsAvailable || usersTable.selected[0]?.spot"
+        [disabled]="!numCountrySpotsAvailable || usersTable.selected[0]?.spot ||
+                    !usersTable.selected[0]?.registrationAt"
         (click)="assignCountrySpot(usersTable.selected[0])"
       >
         <ion-icon name="ticket" slot="icon-only"></ion-icon>


### PR DESCRIPTION
Solve bug that makes possible to assign spot to a non registered user in the app (it happens in 1st round spot assignment)