### PR TITLE
Fix: add spot price on assignment spot template

### DIFF
--- a/back-end/src/handlers/eventSpots.ts
+++ b/back-end/src/handlers/eventSpots.ts
@@ -132,6 +132,7 @@ class EventSpotsRC extends ResourceController {
     const templateData = {
       name: user.getName(),
       spotType: this.spot.type,
+      price: this.configurations.pricePerSpotTypes[this.spot.type],
       reference: this.spot.spotId,
       deadline: toISODate(aWeekFromNow)
     };
@@ -203,6 +204,7 @@ class EventSpotsRC extends ResourceController {
       const templateData = {
         name: targetUser.getName(),
         spotType: this.spot.type,
+        price: this.configurations.pricePerSpotTypes[this.spot.type],
         reference: this.spot.spotId,
         deadline: toISODate(aWeekFromNow)
       };


### PR DESCRIPTION
Solve bug to make it possible to show price on assign/transfer spot email