### PR TITLE
#188 ESN international table view

### DIFF
--- a/back-end/src/handlers/eventSpots.ts
+++ b/back-end/src/handlers/eventSpots.ts
@@ -71,7 +71,9 @@ class EventSpotsRC extends ResourceController {
       throw new HandledError('Spot not found');
     }
 
-    if (!this.user.permissions.canManageRegistrations && this.spot.sectionCountry !== this.user.sectionCountry)
+    if (!this.user.permissions.canManageRegistrations &&
+        (!this.user.permissions.isESNInternationalLeader && this.spot.sectionCountry !== this.user.sectionCountry) &&
+        (this.user.permissions.isESNInternationalLeader && this.spot.sectionCountry !== "ESN International"))
       throw new HandledError('Unauthorized');
   }
 
@@ -347,7 +349,10 @@ class EventSpotsRC extends ResourceController {
   protected async getResources(): Promise<EventSpot[]> {
     let spots = (await ddb.scan({ TableName: DDB_TABLES.eventSpots })).map(x => new EventSpot(x));
     if (!this.user.permissions.canManageRegistrations)
-      spots = spots.filter(x => x.sectionCountry === this.user.sectionCountry);
+      spots = spots.filter(x =>
+       (!this.user.permissions.isESNInternationalLeader && x.sectionCountry === this.user.sectionCountry) ||
+       (this.user.permissions.isESNInternationalLeader && x.sectionCountry === 'ESN International'));
+
     return spots;
   }
 

--- a/back-end/src/handlers/galaxy.ts
+++ b/back-end/src/handlers/galaxy.ts
@@ -60,6 +60,7 @@ class GalaxyRC extends ResourceController {
       let user: User;
       let firstAccess = false;
       const [day, month, year] = attributes['cas:birthdate'][0].split('/');
+      const isESNInternational = attributes['cas:roles'].some((role: string) => role.startsWith('International'));
 
       try {
         user = new User(await ddb.get({ TableName: DDB_TABLES.users, Key: { userId } }));
@@ -67,6 +68,7 @@ class GalaxyRC extends ResourceController {
         user.sectionCountry = attributes['cas:country'][0];
         user.sectionName = attributes['cas:section'][0];
         user.birthDate = new Date(`${year}-${month}-${day}`).toISOString();
+        user.isESNInternational = isESNInternational;
       } catch (error) {
         firstAccess = true;
         user = new User({
@@ -79,7 +81,8 @@ class GalaxyRC extends ResourceController {
           sectionCode: attributes['cas:sc'][0],
           sectionCountry: attributes['cas:country'][0],
           sectionName: attributes['cas:section'][0],
-          birthDate: new Date(`${year}-${month}-${day}`).toISOString()
+          birthDate: new Date(`${year}-${month}-${day}`).toISOString(),
+          isESNInternational
         });
       }
 

--- a/back-end/src/handlers/users.ts
+++ b/back-end/src/handlers/users.ts
@@ -361,7 +361,9 @@ class UsersRC extends ResourceController {
 
     let users = (await ddb.scan({ TableName: DDB_TABLES.users })).map(x => new User(x));
     if (!this.reqUser.permissions.canManageRegistrations)
-      users = users.filter(x => x.sectionCountry === this.reqUser.sectionCountry);
+      users = users.filter(x =>
+       (!this.reqUser.permissions.isESNInternationalLeader && x.sectionCountry === this.reqUser.sectionCountry) ||
+       (this.reqUser.permissions.isESNInternationalLeader && x.isESNInternational));
 
     return users;
   }

--- a/back-end/src/models/user.model.ts
+++ b/back-end/src/models/user.model.ts
@@ -97,6 +97,10 @@ export class User extends Resource {
    * The user's meal tickets and their status.
    */
   mealTickets: { [mealId: string]: MealTicket };
+  /**
+   * Whether the user is part of the ESN International.
+   */
+  isESNInternational: boolean;
 
   load(x: any): void {
     super.load(x);
@@ -115,6 +119,7 @@ export class User extends Resource {
       this.sectionCountry = this.clean(x.sectionCountry, String);
       this.sectionName = this.clean(x.sectionName, String);
       this.ESNcard = this.clean(x.ESNcard, String);
+      this.isESNInternational = this.clean(x.isESNInternational, Boolean, false);
     }
 
     this.permissions = new UserPermissions(x.permissions);
@@ -146,6 +151,7 @@ export class User extends Resource {
       this.sectionCountry = safeData.sectionCountry;
       this.sectionName = safeData.sectionName;
       this.birthDate = safeData.birthDate;
+      this.isESNInternational = safeData.isESNInternational;
     }
 
     this.permissions = safeData.permissions;

--- a/back-end/src/models/user.model.ts
+++ b/back-end/src/models/user.model.ts
@@ -262,6 +262,11 @@ export class UserPermissions {
    * If this is true, all other permissions are.
    */
   protected _isAdmin: boolean;
+  /**
+   * Whether the user can manage spots for the ESN International delegation.
+   */
+  isESNInternationalLeader: boolean;
+
   get isAdmin(): boolean {
     return this._isAdmin;
   }
@@ -272,6 +277,7 @@ export class UserPermissions {
       this.canManageRegistrations = true;
       this.canManageContents = true;
       this.isStaff = true;
+      this.isESNInternationalLeader = true;
     }
   }
 
@@ -281,6 +287,7 @@ export class UserPermissions {
     this.canManageRegistrations = Boolean(x.canManageRegistrations);
     this.canManageContents = Boolean(x.canManageContents);
     this.isStaff = Boolean(x.isStaff);
+    this.isESNInternationalLeader = Boolean(x.isESNInternationalLeader);
     // as last, to change any other attribute in case it's `true`
     this.isAdmin = Boolean(x._isAdmin);
   }

--- a/front-end/src/app/tabs/manage/spots/addSpots.component.html
+++ b/front-end/src/app/tabs/manage/spots/addSpots.component.html
@@ -40,6 +40,9 @@
         [(ngModel)]="spot.sectionCountry"
         [class.fieldHasError]="hasFieldAnError('sectionCountry')"
       >
+        <ion-select-option value="ESN International">
+          {{ 'USERS.ESN_INTERNATIONAL' | translate }}
+        </ion-select-option>
         <ion-select-option *ngFor="let country of app.configurations.sectionCountries" [value]="country">
           {{ country }}
         </ion-select-option>

--- a/front-end/src/app/tabs/manage/users/users.page.html
+++ b/front-end/src/app/tabs/manage/users/users.page.html
@@ -106,6 +106,7 @@
       >
         <ion-select-option [value]="null">{{ 'COMMON.ALL' | translate }}</ion-select-option>
         <ion-select-option value="no">{{ 'USERS.EXTERNAL_GUEST' | translate }}</ion-select-option>
+        <ion-select-option value="international">{{ 'USERS.ESN_INTERNATIONAL' | translate }}</ion-select-option>
         <ion-select-option *ngFor="let country of app.configurations.sectionCountries" [value]="country">
           {{ country }}
         </ion-select-option>

--- a/front-end/src/app/tabs/manage/users/users.page.ts
+++ b/front-end/src/app/tabs/manage/users/users.page.ts
@@ -155,9 +155,10 @@ export class UsersPage implements OnInit {
         this.filters.paymentConfirmed === 'yes' ? !!x.spot?.paymentConfirmedAt : !x.spot?.paymentConfirmedAt
       );
     if (this.filters.sectionCountry)
-      this.filteredUsers = this.filteredUsers.filter(x =>
-        this.filters.sectionCountry === 'no' ? !x.sectionCountry : this.filters.sectionCountry === x.sectionCountry
-      );
+      this.filteredUsers = this.filteredUsers.filter(x => {
+        if (this.filters.sectionCountry === 'international') return x.isESNInternational;
+        return this.filters.sectionCountry === 'no' ? !x.sectionCountry : this.filters.sectionCountry === x.sectionCountry;
+      });
 
     this.calcFooterTotals();
 
@@ -485,5 +486,5 @@ interface RowsFilters {
   spot: null | 'no' | string;
   proofOfPaymentUploaded: null | 'yes' | 'no';
   paymentConfirmed: null | 'yes' | 'no';
-  sectionCountry: string | 'no' | null;
+  sectionCountry: string | 'no' | 'international' | null;
 }

--- a/front-end/src/app/tabs/manage/users/users.page.ts
+++ b/front-end/src/app/tabs/manage/users/users.page.ts
@@ -104,7 +104,7 @@ export class UsersPage implements OnInit {
 
       if (this.app.user.permissions.isESNInternationalLeader) {
         this.numCountrySpotsAvailable = this.spots.filter(
-          x => this.app.user.sectionCountry === 'ESN International' && !x.userId
+          x => x.sectionCountry === 'ESN International' && !x.userId
         ).length;
       } else {
         this.numCountrySpotsAvailable = this.spots.filter(
@@ -409,7 +409,10 @@ export class UsersPage implements OnInit {
     alert.present();
   }
   async assignCountrySpot(user: User): Promise<void> {
-    if (!this.numCountrySpotsAvailable || user.spot || user.sectionCountry !== this.app.user.sectionCountry) return;
+    if (!this.numCountrySpotsAvailable || user.spot ||
+        (!this.app.user.permissions.isESNInternationalLeader && user.sectionCountry !== this.app.user.sectionCountry) ||
+        (this.app.user.permissions.isESNInternationalLeader && !user.isESNInternational)
+       ) return;
 
     const doAssign = async (): Promise<void> => {
       try {
@@ -417,7 +420,7 @@ export class UsersPage implements OnInit {
         let firstAvailableSpot = null;
         if (this.app.user.permissions.isESNInternationalLeader) {
           firstAvailableSpot = this.spots.find(
-            x => this.app.user.sectionCountry === 'ESN International' && !x.userId
+            x => x.sectionCountry === 'ESN International' && !x.userId
           );
         } else {
           firstAvailableSpot = this.spots.find(

--- a/front-end/src/app/tabs/manage/users/users.page.ts
+++ b/front-end/src/app/tabs/manage/users/users.page.ts
@@ -101,15 +101,24 @@ export class UsersPage implements OnInit {
     try {
       await this.loading.show();
       [this.users, this.spots] = await Promise.all([this._users.getList(), this._spots.getList()]);
-      this.numCountrySpotsAvailable = this.spots.filter(
-        x => x.sectionCountry === this.app.user.sectionCountry && !x.userId
-      ).length;
+
+      if (this.app.user.permissions.isESNInternationalLeader) {
+        this.numCountrySpotsAvailable = this.spots.filter(
+          x => this.app.user.sectionCountry === 'ESN International' && !x.userId
+        ).length;
+      } else {
+        this.numCountrySpotsAvailable = this.spots.filter(
+          x => x.sectionCountry === this.app.user.sectionCountry && !x.userId
+        ).length;
+      }
+
       this.filter(this.searchbar?.value);
     } catch (error) {
       this.message.error('COMMON.COULDNT_LOAD_LIST');
     } finally {
       this.loading.hide();
     }
+
   }
   ionViewWillEnter(): void {
     if (!(this.app.user.permissions.canManageRegistrations || this.app.user.permissions.isCountryLeader))
@@ -362,6 +371,13 @@ export class UsersPage implements OnInit {
         value: 'isStaff',
         checked: user.permissions.isStaff,
         label: this.t._('USER.IS_STAFF')
+      },
+      {
+        type: 'checkbox',
+        name: 'isESNInternationalLeader',
+        value: 'isESNInternationalLeader',
+        checked: user.permissions.isESNInternationalLeader,
+        label: this.t._('USER.IS_ESN_INTERNATIONAL_LEADER')
       }
     ];
     const buttons = [
@@ -398,7 +414,16 @@ export class UsersPage implements OnInit {
     const doAssign = async (): Promise<void> => {
       try {
         await this.loading.show();
-        const firstAvailableSpot = this.spots.find(x => x.sectionCountry === this.app.user.sectionCountry && !x.userId);
+        let firstAvailableSpot = null;
+        if (this.app.user.permissions.isESNInternationalLeader) {
+          firstAvailableSpot = this.spots.find(
+            x => this.app.user.sectionCountry === 'ESN International' && !x.userId
+          );
+        } else {
+          firstAvailableSpot = this.spots.find(
+            x => x.sectionCountry === this.app.user.sectionCountry && !x.userId
+          );
+        }
         if (!firstAvailableSpot) return;
         await this._spots.assignToUser(firstAvailableSpot, user);
         firstAvailableSpot.userId = user.userId;

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -213,6 +213,7 @@
     "CAN_MANAGE_CONTENTS": "Can manage contents",
     "CAN_MANAGE_CONTENTS_SHORT": "Cont.",
     "IS_STAFF": "Is staff",
+    "IS_ESN_INTERNATIONAL_LEADER": "Is ESN International leader",
     "IS_STAFF_SHORT": "Staff",
     "COUNTRY_LEADER_MANAGE_USERS": "Manage delegation",
     "REGISTRATION": "Event registration",

--- a/front-end/src/assets/i18n/en.json
+++ b/front-end/src/assets/i18n/en.json
@@ -266,6 +266,7 @@
     "PAYMENT_CONFIRMED": "Payment confirmed",
     "SECTION_COUNTRY": "ESN country",
     "EXTERNAL_GUEST": "External guest",
+    "ESN_INTERNATIONAL": "ESN International",
     "APPLY_TO": "Apply to:",
     "ACTIONS_ON_USER": "Actions on {{user}}",
     "ASSIGN_SPOT": "Assign spot",


### PR DESCRIPTION
Allows DL to filter ESN International users (users having a role starting with "International" in Accounts) in the "manage" tab